### PR TITLE
Add system inspection and auto-tuning for worker threads

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,3 +27,6 @@ webpki-roots = "0.25"
 core_affinity = "0.5"
 hyper-util = { version = "0.1", features = ["server", "tokio"] }
 http-body-util = "0.1"
+raw-cpuid = "10"
+sysinfo = { version = "0.30" }
+cfg-if = "1"

--- a/crates/oxide-core/Cargo.toml
+++ b/crates/oxide-core/Cargo.toml
@@ -23,3 +23,9 @@ randomx-rs = { version = "1.4", optional = true }
 tokio-rustls = { workspace = true }
 webpki-roots = { workspace = true }
 core_affinity = { workspace = true }
+raw-cpuid = { workspace = true }
+sysinfo = { workspace = true }
+cfg-if = { workspace = true }
+
+[target.'cfg(windows)'.dependencies]
+windows = { version = "0.52", features = ["Win32_System_Memory"] }

--- a/crates/oxide-core/src/lib.rs
+++ b/crates/oxide-core/src/lib.rs
@@ -1,9 +1,11 @@
 pub mod config;
 pub mod devfee;
 pub mod stratum;
+pub mod system;
 pub mod worker;
 
 pub use config::Config;
 pub use devfee::{DevFeeScheduler, DEV_FEE_BASIS_POINTS, DEV_WALLET_ADDRESS};
 pub use stratum::{PoolJob, StratumClient};
+pub use system::{SystemInfo, RANDOMX_DATASET_BYTES};
 pub use worker::{spawn_workers, Share, WorkItem};

--- a/crates/oxide-core/src/system.rs
+++ b/crates/oxide-core/src/system.rs
@@ -1,0 +1,97 @@
+//! System inspection utilities for tuning RandomX.
+//!
+//! Provides cross-platform helpers to detect CPU features,
+//! available memory, and huge page support so the miner can
+//! automatically choose sensible defaults.
+
+use raw_cpuid::CpuId;
+use sysinfo::{System, SystemExt};
+
+/// Size of the RandomX dataset when operating in `FLAG_FULL_MEM` mode.
+pub const RANDOMX_DATASET_BYTES: u64 = 2 * 1024 * 1024 * 1024; // 2 GiB
+
+/// Collected system properties relevant for tuning the miner.
+#[derive(Debug, Clone)]
+pub struct SystemInfo {
+    /// Number of physical CPU cores.
+    pub physical_cores: usize,
+    /// Total system memory in bytes.
+    pub total_memory: u64,
+    /// Available system memory in bytes.
+    pub available_memory: u64,
+    /// Whether the operating system currently has huge/large pages enabled.
+    pub huge_pages: bool,
+    /// Whether AES-NI instructions are supported.
+    pub has_aes: bool,
+    /// Whether AVX2 instructions are supported.
+    pub has_avx2: bool,
+}
+
+impl SystemInfo {
+    /// Gather a snapshot of the system's capabilities.
+    pub fn gather() -> Self {
+        let mut sys = System::new();
+        sys.refresh_memory();
+
+        let physical_cores = num_cpus::get_physical();
+        let total_memory = sys.total_memory() * 1024; // KiB -> bytes
+        let available_memory = sys.available_memory() * 1024; // KiB -> bytes
+
+        let cpuid = CpuId::new();
+        let has_aes = cpuid
+            .get_feature_info()
+            .map(|f| f.has_aesni())
+            .unwrap_or(false);
+        let has_avx2 = cpuid
+            .get_extended_feature_info()
+            .map(|f| f.has_avx2())
+            .unwrap_or(false);
+
+        let huge_pages = huge_pages_available();
+
+        Self {
+            physical_cores,
+            total_memory,
+            available_memory,
+            huge_pages,
+            has_aes,
+            has_avx2,
+        }
+    }
+
+    /// Determine a recommended number of mining threads based on
+    /// physical cores and available memory. Ensures at least one thread.
+    pub fn recommended_thread_count(&self) -> usize {
+        let mem_based = (self.available_memory / RANDOMX_DATASET_BYTES) as usize;
+        let mem_based = mem_based.max(1);
+        let cores = self.physical_cores.max(1);
+        std::cmp::min(mem_based, cores)
+    }
+}
+
+/// Check whether huge/large pages are available on the current host.
+pub fn huge_pages_available() -> bool {
+    cfg_if::cfg_if! {
+        if #[cfg(target_os = "linux")] {
+            // Parse /proc/meminfo for HugePages_* entries.
+            if let Ok(meminfo) = std::fs::read_to_string("/proc/meminfo") {
+                let mut total = 0u64;
+                let mut free = 0u64;
+                for line in meminfo.lines() {
+                    if line.starts_with("HugePages_Total:") {
+                        total = line.split_whitespace().nth(1).and_then(|v| v.parse().ok()).unwrap_or(0);
+                    } else if line.starts_with("HugePages_Free:") {
+                        free = line.split_whitespace().nth(1).and_then(|v| v.parse().ok()).unwrap_or(0);
+                    }
+                }
+                return total > 0 && free > 0;
+            }
+            false
+        } else if #[cfg(target_os = "windows")] {
+            use windows::Win32::System::Memory::GetLargePageMinimum;
+            unsafe { GetLargePageMinimum() > 0 }
+        } else {
+            false
+        }
+    }
+}

--- a/crates/oxide-core/src/worker.rs
+++ b/crates/oxide-core/src/worker.rs
@@ -3,6 +3,7 @@ use tokio::sync::{broadcast, mpsc};
 use tracing::{info, warn};
 
 use crate::stratum::PoolJob;
+use crate::system;
 
 #[derive(Clone, Debug)]
 pub struct WorkItem {
@@ -26,8 +27,12 @@ pub fn spawn_workers(
     affinity: bool,
     large_pages: bool,
 ) -> Vec<tokio::task::JoinHandle<()>> {
+    let use_large_pages = large_pages && system::huge_pages_available();
+    if large_pages && !use_large_pages {
+        warn!("huge pages requested but not available on this system");
+    }
     #[cfg(feature = "randomx")]
-    engine::set_large_pages(large_pages);
+    engine::set_large_pages(use_large_pages);
     let core_ids = if affinity {
         core_affinity::get_core_ids()
     } else {
@@ -221,7 +226,7 @@ async fn randomx_worker_loop(
     let mut work: Option<WorkItem> = None;
 
     // Precompute once (Send + Copy)
-    let threads_u32: u32 = num_cpus::get() as u32;
+    let threads_u32: u32 = worker_count as u32;
 
     loop {
         if work.is_none() {
@@ -293,7 +298,8 @@ async fn randomx_worker_loop(
                         let mut be_bytes = digest;
                         be_bytes.reverse();
                         let be_hex = hex::encode(be_bytes);
-                        let wrote_nonce = u32::from_le_bytes([blob[39], blob[40], blob[41], blob[42]]);
+                        let wrote_nonce =
+                            u32::from_le_bytes([blob[39], blob[40], blob[41], blob[42]]);
 
                         tracing::debug!(
                             job_id = %j.job_id,
@@ -344,8 +350,12 @@ fn meets_target(hash: &[u8; 32], target_hex: &str) -> bool {
     // Fast path: 32-bit LE share target
     if target_hex.len() <= 8 {
         if let Ok(mut b) = hex::decode(target_hex) {
-            if b.len() > 4 { b.truncate(4); }
-            while b.len() < 4 { b.push(0); }
+            if b.len() > 4 {
+                b.truncate(4);
+            }
+            while b.len() < 4 {
+                b.push(0);
+            }
             let t32 = u32::from_le_bytes([b[0], b[1], b[2], b[3]]);
 
             // hash is LE; MSB 32 bits live in the last 4 bytes
@@ -368,7 +378,9 @@ fn meets_target(hash: &[u8; 32], target_hex: &str) -> bool {
 
     // Wider target: treat as 256-bit BE and compare to the LE hash by reversing.
     if let Ok(mut t) = hex::decode(target_hex) {
-        if t.is_empty() || t.len() > 32 { return false; }
+        if t.is_empty() || t.len() > 32 {
+            return false;
+        }
         if t.len() < 32 {
             let mut pad = vec![0u8; 32 - t.len()]; // left-pad for BE
             pad.extend_from_slice(&t);
@@ -376,7 +388,9 @@ fn meets_target(hash: &[u8; 32], target_hex: &str) -> bool {
         }
         // Compare as 256-bit BE: reverse LE hash into BE without allocation
         for (hb, tb) in hash.iter().rev().zip(t.iter()) {
-            if hb != tb { return *hb < *tb; }
+            if hb != tb {
+                return *hb < *tb;
+            }
         }
         true
     } else {

--- a/crates/oxide-miner/src/main.rs
+++ b/crates/oxide-miner/src/main.rs
@@ -1,14 +1,15 @@
 use anyhow::Result;
 use clap::Parser;
+use http_body_util::Full;
+use hyper::body::{Bytes, Incoming};
 use hyper::server::conn::http1;
 use hyper::service::service_fn;
 use hyper::{Method, Request, Response};
-use hyper::body::{Incoming, Bytes};
-use http_body_util::Full;
 use hyper_util::rt::TokioIo;
 use oxide_core::worker::{Share, WorkItem};
 use oxide_core::{
-    spawn_workers, Config, DevFeeScheduler, StratumClient, DEV_FEE_BASIS_POINTS, DEV_WALLET_ADDRESS,
+    spawn_workers, Config, DevFeeScheduler, StratumClient, SystemInfo, DEV_FEE_BASIS_POINTS,
+    DEV_WALLET_ADDRESS,
 };
 use std::convert::Infallible;
 use std::net::SocketAddr;
@@ -18,12 +19,7 @@ use std::sync::{
 };
 use tokio::net::TcpListener;
 use tracing::{info, warn};
-use tracing_subscriber::{
-    fmt,
-    layer::SubscriberExt,
-    util::SubscriberInitExt,
-    EnvFilter,
-};
+use tracing_subscriber::{fmt, layer::SubscriberExt, util::SubscriberInitExt, EnvFilter};
 
 #[derive(Parser, Debug)]
 #[command(
@@ -76,6 +72,18 @@ struct Args {
 #[tokio::main]
 async fn main() -> Result<()> {
     let args = Args::parse();
+
+    let sys = SystemInfo::gather();
+    if !sys.huge_pages {
+        warn!("huge pages not detected; mining performance may suffer");
+    }
+    info!(
+        cores = sys.physical_cores,
+        aes = sys.has_aes,
+        avx2 = sys.has_avx2,
+        huge_pages = sys.huge_pages,
+        "system_info"
+    );
 
     // Prefer RUST_LOG if set; otherwise use --debug to bump verbosity.
     let env_filter = EnvFilter::try_from_default_env().unwrap_or_else(|_| {
@@ -141,7 +149,10 @@ async fn main() -> Result<()> {
     // MPSC: shares <- workers
     let (shares_tx, mut shares_rx) = tokio::sync::mpsc::unbounded_channel::<Share>();
 
-    let n_workers = cfg.threads.unwrap_or_else(|| num_cpus::get());
+    let n_workers = cfg
+        .threads
+        .unwrap_or_else(|| sys.recommended_thread_count());
+    info!("using {} worker threads", n_workers);
     let _workers = spawn_workers(
         n_workers,
         jobs_tx.clone(),
@@ -150,10 +161,10 @@ async fn main() -> Result<()> {
         cfg.huge_pages,
     );
 
-    let main_pool   = cfg.pool.clone();
+    let main_pool = cfg.pool.clone();
     let user_wallet = cfg.wallet.clone();
-    let pass        = cfg.pass.clone().unwrap_or_else(|| "x".into());
-    let agent       = cfg.agent.clone();
+    let pass = cfg.pass.clone().unwrap_or_else(|| "x".into());
+    let agent = cfg.agent.clone();
 
     info!(
         "dev fee fixed at {} bps (1%): {}",
@@ -167,7 +178,9 @@ async fn main() -> Result<()> {
     if let Some(port) = cfg.api_port {
         let a = accepted.clone();
         let r = rejected.clone();
-        tokio::spawn(async move { run_http_api(port, a, r).await; });
+        tokio::spawn(async move {
+            run_http_api(port, a, r).await;
+        });
     }
 
     // Snapshot flags for the async task
@@ -188,18 +201,28 @@ async fn main() -> Result<()> {
             use tokio::time::{sleep, Duration};
 
             loop {
-                let (mut client, initial_job) =
-                    match StratumClient::connect_and_login(&main_pool, &user_wallet, &pass, &agent, tls).await {
-                        Ok(v) => v,
-                        Err(e) => {
-                            eprintln!("connect/login failed: {e}");
-                            sleep(Duration::from_secs(5)).await;
-                            continue;
-                        }
-                    };
+                let (mut client, initial_job) = match StratumClient::connect_and_login(
+                    &main_pool,
+                    &user_wallet,
+                    &pass,
+                    &agent,
+                    tls,
+                )
+                .await
+                {
+                    Ok(v) => v,
+                    Err(e) => {
+                        eprintln!("connect/login failed: {e}");
+                        sleep(Duration::from_secs(5)).await;
+                        continue;
+                    }
+                };
 
                 if let Some(job) = initial_job {
-                    let _ = jobs_tx.send(WorkItem { job, is_devfee: false });
+                    let _ = jobs_tx.send(WorkItem {
+                        job,
+                        is_devfee: false,
+                    });
                 }
 
                 let mut devfee = DevFeeScheduler::new();


### PR DESCRIPTION
## Summary
- add system inspection utilities to detect CPU features, memory and huge pages
- auto-tune worker thread count and warn when huge pages are unavailable
- ensure RandomX dataset build respects requested thread count

## Testing
- `cargo test` *(fails: failed to download from `https://index.crates.io/config.json`)*

------
https://chatgpt.com/codex/tasks/task_e_68b6083d0f2483339818f3f9abd6fb52