### PR TITLE
Optimize mining hot path and configuration

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,3 +31,6 @@ sysinfo = "0.30"
 raw-cpuid = "11"
 windows-sys = { version = "0.52", features = ["Win32_System_Memory"] }
 
+[profile.release]
+lto = true
+

--- a/crates/oxide-core/src/config.rs
+++ b/crates/oxide-core/src/config.rs
@@ -21,6 +21,10 @@ pub struct Config {
     /// request huge/large pages for RandomX dataset
     pub huge_pages: bool,
     pub agent: String,
+    /// number of hashes to compute per batch before yielding
+    pub batch_size: usize,
+    /// whether workers yield to the runtime between batches
+    pub yield_between_batches: bool,
 }
 
 impl Default for Config {
@@ -36,6 +40,8 @@ impl Default for Config {
             affinity: false,
             huge_pages: false,
             agent: format!("OxideMiner/{}", env!("CARGO_PKG_VERSION")),
+            batch_size: 10_000,
+            yield_between_batches: true,
         }
     }
 }
@@ -56,5 +62,7 @@ mod tests {
         assert!(!cfg.affinity);
         assert!(!cfg.huge_pages);
         assert!(cfg.agent.starts_with("OxideMiner/"));
+        assert_eq!(cfg.batch_size, 10_000);
+        assert!(cfg.yield_between_batches);
     }
 }

--- a/crates/oxide-core/src/lib.rs
+++ b/crates/oxide-core/src/lib.rs
@@ -7,5 +7,7 @@ pub mod worker;
 pub use config::Config;
 pub use devfee::{DevFeeScheduler, DEV_FEE_BASIS_POINTS, DEV_WALLET_ADDRESS};
 pub use stratum::{PoolJob, StratumClient};
-pub use system::{cpu_has_aes, huge_pages_enabled, recommended_thread_count, AutoTuneSnapshot, autotune_snapshot};
+pub use system::{
+    autotune_snapshot, cpu_has_aes, huge_pages_enabled, recommended_thread_count, AutoTuneSnapshot,
+};
 pub use worker::{spawn_workers, Share, WorkItem};


### PR DESCRIPTION
## Summary
- Add configurable batch size and optional scheduler yielding for worker threads
- Randomize worker nonces and cache parsed targets to reduce per-hash overhead
- Tune system heuristics and buffering for faster RandomX and Stratum handling

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68bd91b4f71883339373b731ca422413