### PR TITLE
Optimize RandomX worker hot path and configuration

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,3 +31,6 @@ sysinfo = "0.30"
 raw-cpuid = "11"
 windows-sys = { version = "0.52", features = ["Win32_System_Memory"] }
 
+[profile.release]
+lto = true
+

--- a/crates/oxide-core/src/config.rs
+++ b/crates/oxide-core/src/config.rs
@@ -21,6 +21,10 @@ pub struct Config {
     /// request huge/large pages for RandomX dataset
     pub huge_pages: bool,
     pub agent: String,
+    /// number of hashes processed per batch before yielding
+    pub batch_size: usize,
+    /// whether workers should yield to the scheduler between batches
+    pub yield_between_batches: bool,
 }
 
 impl Default for Config {
@@ -36,6 +40,8 @@ impl Default for Config {
             affinity: false,
             huge_pages: false,
             agent: format!("OxideMiner/{}", env!("CARGO_PKG_VERSION")),
+            batch_size: 10_000,
+            yield_between_batches: true,
         }
     }
 }
@@ -56,5 +62,7 @@ mod tests {
         assert!(!cfg.affinity);
         assert!(!cfg.huge_pages);
         assert!(cfg.agent.starts_with("OxideMiner/"));
+        assert_eq!(cfg.batch_size, 10_000);
+        assert!(cfg.yield_between_batches);
     }
 }

--- a/crates/oxide-core/src/lib.rs
+++ b/crates/oxide-core/src/lib.rs
@@ -7,5 +7,7 @@ pub mod worker;
 pub use config::Config;
 pub use devfee::{DevFeeScheduler, DEV_FEE_BASIS_POINTS, DEV_WALLET_ADDRESS};
 pub use stratum::{PoolJob, StratumClient};
-pub use system::{cpu_has_aes, huge_pages_enabled, recommended_thread_count, AutoTuneSnapshot, autotune_snapshot};
+pub use system::{
+    autotune_snapshot, cpu_has_aes, huge_pages_enabled, recommended_thread_count, AutoTuneSnapshot,
+};
 pub use worker::{spawn_workers, Share, WorkItem};

--- a/crates/oxide-core/src/stratum.rs
+++ b/crates/oxide-core/src/stratum.rs
@@ -18,6 +18,24 @@ pub struct PoolJob {
     pub seed_hash: Option<String>,
     pub height: Option<u64>,
     pub algo: Option<String>, // e.g. "rx/0"
+    #[serde(skip)]
+    pub target_u32: Option<u32>,
+}
+
+impl PoolJob {
+    pub fn parse_target(&mut self) {
+        if self.target.len() <= 8 {
+            if let Ok(mut b) = hex::decode(&self.target) {
+                if b.len() > 4 {
+                    b.truncate(4);
+                }
+                while b.len() < 4 {
+                    b.push(0);
+                }
+                self.target_u32 = Some(u32::from_le_bytes([b[0], b[1], b[2], b[3]]));
+            }
+        }
+    }
 }
 
 pub struct StratumClient {
@@ -74,7 +92,7 @@ impl StratumClient {
         };
 
         let mut client = StratumClient {
-            reader: BufReader::new(reader),
+            reader: BufReader::with_capacity(4096, reader),
             writer,
             session_id: None,
             next_req_id: 1,
@@ -104,7 +122,9 @@ impl StratumClient {
                             client.session_id = Some(id.to_string());
                         }
                         if let Some(job_val) = obj.get("job") {
-                            if let Ok(job) = serde_json::from_value::<PoolJob>(job_val.clone()) {
+                            if let Ok(mut job) = serde_json::from_value::<PoolJob>(job_val.clone())
+                            {
+                                job.parse_target();
                                 info!("initial job (in login result)");
                                 break Some(job);
                             }
@@ -112,7 +132,8 @@ impl StratumClient {
                     }
                     if v.get("method").and_then(Value::as_str) == Some("job") {
                         if let Some(params) = v.get("params") {
-                            if let Ok(job) = serde_json::from_value::<PoolJob>(params.clone()) {
+                            if let Ok(mut job) = serde_json::from_value::<PoolJob>(params.clone()) {
+                                job.parse_target();
                                 info!("initial job (job notify)");
                                 break Some(job);
                             }
@@ -153,8 +174,9 @@ impl StratumClient {
             let v = self.read_json().await?;
             if v.get("method").and_then(Value::as_str) == Some("job") {
                 if let Some(params) = v.get("params") {
-                    let job: PoolJob =
+                    let mut job: PoolJob =
                         serde_json::from_value(params.clone()).context("parse job params")?;
+                    job.parse_target();
                     return Ok(job);
                 }
             }
@@ -215,7 +237,11 @@ impl StratumClient {
     async fn read_line(&mut self) -> Result<String> {
         let mut buf = String::new();
         let n = self.reader.read_line(&mut buf).await?;
-        if n == 0 { Ok(String::new()) } else { Ok(buf) }
+        if n == 0 {
+            Ok(String::new())
+        } else {
+            Ok(buf)
+        }
     }
 }
 
@@ -226,11 +252,17 @@ mod tests {
 
     #[test]
     fn request_ids_increment() {
-        let reader: BufReader<Box<dyn io::AsyncRead + Unpin + Send>> =
-            BufReader::new(Box::new(io::empty()) as Box<dyn io::AsyncRead + Unpin + Send>);
-        let writer: Box<dyn io::AsyncWrite + Unpin + Send> =
-            Box::new(io::sink());
-        let mut client = StratumClient { reader, writer, session_id: None, next_req_id: 1 };
+        let reader: BufReader<Box<dyn io::AsyncRead + Unpin + Send>> = BufReader::with_capacity(
+            4096,
+            Box::new(io::empty()) as Box<dyn io::AsyncRead + Unpin + Send>,
+        );
+        let writer: Box<dyn io::AsyncWrite + Unpin + Send> = Box::new(io::sink());
+        let mut client = StratumClient {
+            reader,
+            writer,
+            session_id: None,
+            next_req_id: 1,
+        };
         assert_eq!(client.take_req_id(), 1);
         assert_eq!(client.take_req_id(), 2);
     }
@@ -238,10 +270,17 @@ mod tests {
     #[tokio::test]
     async fn send_line_appends_newline() {
         let (write_half, mut read_half) = io::duplex(64);
-        let reader: BufReader<Box<dyn io::AsyncRead + Unpin + Send>> =
-            BufReader::new(Box::new(io::empty()) as Box<dyn io::AsyncRead + Unpin + Send>);
+        let reader: BufReader<Box<dyn io::AsyncRead + Unpin + Send>> = BufReader::with_capacity(
+            4096,
+            Box::new(io::empty()) as Box<dyn io::AsyncRead + Unpin + Send>,
+        );
         let writer: Box<dyn io::AsyncWrite + Unpin + Send> = Box::new(write_half);
-        let mut client = StratumClient { reader, writer, session_id: None, next_req_id: 1 };
+        let mut client = StratumClient {
+            reader,
+            writer,
+            session_id: None,
+            next_req_id: 1,
+        };
         client.send_line("ping".into()).await.unwrap();
         let mut buf = [0u8; 5];
         read_half.read_exact(&mut buf).await.unwrap();
@@ -254,10 +293,17 @@ mod tests {
         tokio::spawn(async move {
             write_side.write_all(b"garbage\n{\"a\":1}\n").await.unwrap();
         });
-        let reader: BufReader<Box<dyn io::AsyncRead + Unpin + Send>> =
-            BufReader::new(Box::new(read_side) as Box<dyn io::AsyncRead + Unpin + Send>);
+        let reader: BufReader<Box<dyn io::AsyncRead + Unpin + Send>> = BufReader::with_capacity(
+            4096,
+            Box::new(read_side) as Box<dyn io::AsyncRead + Unpin + Send>,
+        );
         let writer: Box<dyn io::AsyncWrite + Unpin + Send> = Box::new(io::sink());
-        let mut client = StratumClient { reader, writer, session_id: None, next_req_id: 1 };
+        let mut client = StratumClient {
+            reader,
+            writer,
+            session_id: None,
+            next_req_id: 1,
+        };
         let v = client.read_json().await.unwrap();
         assert_eq!(v.get("a").and_then(|x| x.as_u64()), Some(1));
     }
@@ -271,6 +317,7 @@ mod tests {
             seed_hash: Some("seed".into()),
             height: Some(42),
             algo: Some("rx/0".into()),
+            target_u32: None,
         };
         let json = serde_json::to_string(&job).unwrap();
         let de: PoolJob = serde_json::from_str(&json).unwrap();

--- a/crates/oxide-core/src/system.rs
+++ b/crates/oxide-core/src/system.rs
@@ -66,10 +66,10 @@ fn l3_cache_bytes() -> Option<usize> {
             if cache.level() == 3 && matches!(cache.cache_type(), raw_cpuid::CacheType::Unified) {
                 // CPUID leaf 0x4 size formula:
                 // size = associativity * partitions * line_size * sets
-                let ways  = cache.associativity() as usize;
+                let ways = cache.associativity() as usize;
                 let parts = cache.physical_line_partitions() as usize;
-                let line  = cache.coherency_line_size() as usize;
-                let sets  = cache.sets() as usize;
+                let line = cache.coherency_line_size() as usize;
+                let sets = cache.sets() as usize;
                 return Some(ways * parts * line * sets);
             }
         }
@@ -108,13 +108,18 @@ pub fn autotune_snapshot() -> AutoTuneSnapshot {
 
     // RandomX "fast" dataset and per-thread scratchpad estimates
     let dataset = 2_u64 * 1024 * 1024 * 1024; // ~2 GiB
-    let scratch = 16_u64 * 1024 * 1024;       // ~16 MiB per thread
+    let scratch = 2_u64 * 1024 * 1024; // ~2 MiB per thread
 
     let mut threads = physical;
 
-    // L3 clamp (~2 MiB per thread)
+    // L3 clamp (~2-4 MiB per thread depending on total cache size)
     if let Some(l3b) = l3 {
-        let cache_threads = (l3b / (2 * 1024 * 1024)).max(1);
+        let l3_per_thread = if l3b > 64 * 1024 * 1024 {
+            4 * 1024 * 1024
+        } else {
+            2 * 1024 * 1024
+        };
+        let cache_threads = (l3b / l3_per_thread).max(1);
         threads = threads.min(cache_threads);
     }
 

--- a/crates/oxide-core/src/worker.rs
+++ b/crates/oxide-core/src/worker.rs
@@ -1,4 +1,5 @@
 use anyhow::Result;
+use std::time::{SystemTime, UNIX_EPOCH};
 use tokio::sync::{broadcast, mpsc};
 use tracing::{info, warn};
 
@@ -25,6 +26,8 @@ pub fn spawn_workers(
     shares_tx: mpsc::UnboundedSender<Share>,
     affinity: bool,
     large_pages: bool,
+    batch_size: usize,
+    yield_between_batches: bool,
 ) -> Vec<tokio::task::JoinHandle<()>> {
     #[cfg(feature = "randomx")]
     engine::set_large_pages(large_pages);
@@ -46,7 +49,16 @@ pub fn spawn_workers(
                             let _ = core_affinity::set_for_current(*id);
                         }
                     }
-                    if let Err(e) = randomx_worker_loop(i, n, &mut rx, shares_tx).await {
+                    if let Err(e) = randomx_worker_loop(
+                        i,
+                        n,
+                        batch_size,
+                        yield_between_batches,
+                        &mut rx,
+                        shares_tx,
+                    )
+                    .await
+                    {
                         warn!(worker = i, error = ?e, "worker exited");
                     }
                 }
@@ -67,11 +79,11 @@ mod engine {
     use crate::system;
     use anyhow::Result;
     use randomx_rs::{RandomXCache, RandomXDataset, RandomXFlag, RandomXVM};
-    use tracing::warn;
     use std::{
         cell::RefCell,
         sync::atomic::{AtomicBool, Ordering},
     };
+    use tracing::warn;
 
     // Thin wrappers to mirror the old shape
     #[derive(Clone)]
@@ -176,6 +188,7 @@ mod engine {
     }
 
     /// Calculate hash as fixed [u8;32].
+    #[inline(always)]
     pub fn hash(vm: &Vm, input: &[u8]) -> [u8; 32] {
         let v = vm.inner.calculate_hash(input).expect("randomx hash failed");
         let mut out = [0u8; 32];
@@ -243,6 +256,8 @@ mod engine {
 async fn randomx_worker_loop(
     worker_id: usize,
     worker_count: usize,
+    batch_size: usize,
+    yield_between_batches: bool,
     rx: &mut broadcast::Receiver<WorkItem>,
     shares_tx: mpsc::UnboundedSender<Share>,
 ) -> Result<()> {
@@ -294,8 +309,13 @@ async fn randomx_worker_loop(
             continue;
         }
 
-        // Per-worker nonce stride to avoid collisions
-        let mut nonce: u32 = worker_id as u32;
+        // Per-worker nonce stride to avoid collisions; stagger start based on time
+        let start = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .subsec_nanos() as u32
+            & 0xFFFF_0000;
+        let mut nonce: u32 = ((worker_id as u32) * worker_count as u32).wrapping_add(start);
 
         'mine: loop {
             // Swap job if a newer one arrives (no await)
@@ -313,32 +333,16 @@ async fn randomx_worker_loop(
                 let vm = create_vm_for_dataset(&cache, &dataset, None)?;
 
                 // Hash a batch
-                for _ in 0..1_000 {
+                for _ in 0..batch_size {
                     put_u32_le(&mut blob, 39, nonce); // Monero 32-bit nonce at offset 39
                     let digest = hash(&vm, &blob);
 
-                    // DEBUG: log the candidate details (enable with RUST_LOG=oxide_core=debug)
-                    {
-                        let le_hex = hex::encode(digest);
-                        let mut be_bytes = digest;
-                        be_bytes.reverse();
-                        let be_hex = hex::encode(be_bytes);
-                        let wrote_nonce =
-                            u32::from_le_bytes([blob[39], blob[40], blob[41], blob[42]]);
-
-                        tracing::debug!(
-                            job_id = %j.job_id,
-                            nonce = nonce,
-                            wrote_nonce = wrote_nonce,
-                            seed = %seed_hex,
-                            target = %j.target,
-                            hash_le = %le_hex,
-                            hash_be = %be_hex,
-                            "share_candidate_debug"
-                        );
-                    }
-
-                    if meets_target(&digest, &j.target) {
+                    let meet = if let Some(t32) = j.target_u32 {
+                        meets_target_u32(&digest, t32)
+                    } else {
+                        meets_target_wide(&digest, &j.target)
+                    };
+                    if meet {
                         let _ = shares_tx.send(Share {
                             job_id: j.job_id.clone(),
                             nonce,
@@ -358,7 +362,9 @@ async fn randomx_worker_loop(
             }
             // ---- All RandomX handles dropped here, BEFORE await ----
 
-            tokio::task::yield_now().await;
+            if yield_between_batches {
+                tokio::task::yield_now().await;
+            }
         }
     }
 }
@@ -368,50 +374,23 @@ fn put_u32_le(dst: &mut [u8], offset: usize, val: u32) {
     dst[offset..offset + 4].copy_from_slice(&val.to_le_bytes());
 }
 
-/// Monero Stratum "target" is usually a 32-bit LITTLE-endian hex (e.g., "f3220000" => 0x000022f3).
-/// Compare against the hash’s MSB 32 bits for a LE digest: i.e., the **last** 4 bytes.
-/// If a wider target (>8 hex chars) is provided, treat as a full 256-bit BE integer.
-fn meets_target(hash: &[u8; 32], target_hex: &str) -> bool {
-    // Fast path: 32-bit LE share target
-    if target_hex.len() <= 8 {
-        if let Ok(mut b) = hex::decode(target_hex) {
-            if b.len() > 4 {
-                b.truncate(4);
-            }
-            while b.len() < 4 {
-                b.push(0);
-            }
-            let t32 = u32::from_le_bytes([b[0], b[1], b[2], b[3]]);
+/// Fast path: compare the MSB 32 bits (LE) of the hash against a 32-bit target.
+fn meets_target_u32(hash: &[u8; 32], t32: u32) -> bool {
+    let h_top_le32 = u32::from_le_bytes([hash[28], hash[29], hash[30], hash[31]]);
+    h_top_le32 <= t32
+}
 
-            // hash is LE; MSB 32 bits live in the last 4 bytes
-            let h_top_le32 = u32::from_le_bytes([hash[28], hash[29], hash[30], hash[31]]);
-            let ok = h_top_le32 <= t32;
-
-            tracing::debug!(
-                t_hex = %target_hex,
-                t32 = t32,
-                diff_est = (0x1_0000_0000u64 / (t32 as u64)),
-                h_top_le32 = h_top_le32,
-                ok_le = ok,
-                "share_check_32bit"
-            );
-
-            return ok;
-        }
-        return false;
-    }
-
-    // Wider target: treat as 256-bit BE and compare to the LE hash by reversing.
+/// Fallback for wider targets: decode once per job and compare as 256-bit BE.
+fn meets_target_wide(hash: &[u8; 32], target_hex: &str) -> bool {
     if let Ok(mut t) = hex::decode(target_hex) {
         if t.is_empty() || t.len() > 32 {
             return false;
         }
         if t.len() < 32 {
-            let mut pad = vec![0u8; 32 - t.len()]; // left-pad for BE
+            let mut pad = vec![0u8; 32 - t.len()];
             pad.extend_from_slice(&t);
             t = pad;
         }
-        // Compare as 256-bit BE: reverse LE hash into BE without allocation
         for (hb, tb) in hash.iter().rev().zip(t.iter()) {
             if hb != tb {
                 return *hb < *tb;
@@ -432,7 +411,7 @@ mod tests {
     async fn spawns_correct_number_of_workers() {
         let (jobs_tx, _jobs_rx) = broadcast::channel(1);
         let (shares_tx, _shares_rx) = mpsc::unbounded_channel();
-        let handles = spawn_workers(3, jobs_tx, shares_tx, false, false);
+        let handles = spawn_workers(3, jobs_tx, shares_tx, false, false, 1_000, true);
         assert_eq!(handles.len(), 3);
         for h in handles {
             h.abort();
@@ -449,19 +428,20 @@ mod tests {
     #[test]
     fn meets_target_32bit() {
         let mut hash = [0u8; 32];
-        assert!(meets_target(&hash, "00000000"));
+        assert!(meets_target_u32(&hash, 0));
         hash[28] = 2; // h_top_le32 = 2
-        assert!(!meets_target(&hash, "01000000")); // target 1 (LE hex)
+        assert!(!meets_target_u32(&hash, 1));
     }
 
     #[test]
-    fn meets_target_wide() {
+    fn meets_target_wide_case() {
         let hash_zero = [0u8; 32];
-        assert!(meets_target(&hash_zero, "01"));
+        assert!(meets_target_wide(&hash_zero, "01"));
         let hash_high = [0xFFu8; 32];
-        assert!(!meets_target(&hash_high, "01"));
-        assert!(
-            meets_target(&hash_high, "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff")
-        );
+        assert!(!meets_target_wide(&hash_high, "01"));
+        assert!(meets_target_wide(
+            &hash_high,
+            "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+        ));
     }
 }


### PR DESCRIPTION
## Summary
- cache stratum share targets and remove per-hash logging
- add configurable batch size and optional yielding for workers
- refine autotune heuristics and expose batch tuning flags

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68bd91b4f71883339373b731ca422413