### PR TITLE
Optimize RandomX hot path and tuning

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,3 +31,6 @@ sysinfo = "0.30"
 raw-cpuid = "11"
 windows-sys = { version = "0.52", features = ["Win32_System_Memory"] }
 
+[profile.release]
+lto = true
+

--- a/crates/oxide-core/src/config.rs
+++ b/crates/oxide-core/src/config.rs
@@ -20,6 +20,8 @@ pub struct Config {
     pub affinity: bool,
     /// request huge/large pages for RandomX dataset
     pub huge_pages: bool,
+    /// number of hashes computed per batch before yielding
+    pub batch_size: usize,
     pub agent: String,
 }
 
@@ -35,6 +37,7 @@ impl Default for Config {
             api_port: None,
             affinity: false,
             huge_pages: false,
+            batch_size: 10_000,
             agent: format!("OxideMiner/{}", env!("CARGO_PKG_VERSION")),
         }
     }
@@ -55,6 +58,7 @@ mod tests {
         assert_eq!(cfg.api_port, None);
         assert!(!cfg.affinity);
         assert!(!cfg.huge_pages);
+        assert_eq!(cfg.batch_size, 10_000);
         assert!(cfg.agent.starts_with("OxideMiner/"));
     }
 }

--- a/crates/oxide-core/src/lib.rs
+++ b/crates/oxide-core/src/lib.rs
@@ -7,5 +7,7 @@ pub mod worker;
 pub use config::Config;
 pub use devfee::{DevFeeScheduler, DEV_FEE_BASIS_POINTS, DEV_WALLET_ADDRESS};
 pub use stratum::{PoolJob, StratumClient};
-pub use system::{cpu_has_aes, huge_pages_enabled, recommended_thread_count, AutoTuneSnapshot, autotune_snapshot};
+pub use system::{
+    autotune_snapshot, cpu_has_aes, huge_pages_enabled, recommended_thread_count, AutoTuneSnapshot,
+};
 pub use worker::{spawn_workers, Share, WorkItem};

--- a/crates/oxide-core/src/worker.rs
+++ b/crates/oxide-core/src/worker.rs
@@ -1,4 +1,5 @@
 use anyhow::Result;
+use std::time::{SystemTime, UNIX_EPOCH};
 use tokio::sync::{broadcast, mpsc};
 use tracing::{info, warn};
 
@@ -25,6 +26,7 @@ pub fn spawn_workers(
     shares_tx: mpsc::UnboundedSender<Share>,
     affinity: bool,
     large_pages: bool,
+    batch_size: usize,
 ) -> Vec<tokio::task::JoinHandle<()>> {
     #[cfg(feature = "randomx")]
     engine::set_large_pages(large_pages);
@@ -46,7 +48,8 @@ pub fn spawn_workers(
                             let _ = core_affinity::set_for_current(*id);
                         }
                     }
-                    if let Err(e) = randomx_worker_loop(i, n, &mut rx, shares_tx).await {
+                    if let Err(e) = randomx_worker_loop(i, n, batch_size, &mut rx, shares_tx).await
+                    {
                         warn!(worker = i, error = ?e, "worker exited");
                     }
                 }
@@ -67,11 +70,11 @@ mod engine {
     use crate::system;
     use anyhow::Result;
     use randomx_rs::{RandomXCache, RandomXDataset, RandomXFlag, RandomXVM};
-    use tracing::warn;
     use std::{
         cell::RefCell,
         sync::atomic::{AtomicBool, Ordering},
     };
+    use tracing::warn;
 
     // Thin wrappers to mirror the old shape
     #[derive(Clone)]
@@ -243,6 +246,7 @@ mod engine {
 async fn randomx_worker_loop(
     worker_id: usize,
     worker_count: usize,
+    batch_size: usize,
     rx: &mut broadcast::Receiver<WorkItem>,
     shares_tx: mpsc::UnboundedSender<Share>,
 ) -> Result<()> {
@@ -294,8 +298,13 @@ async fn randomx_worker_loop(
             continue;
         }
 
-        // Per-worker nonce stride to avoid collisions
-        let mut nonce: u32 = worker_id as u32;
+        // Per-worker nonce stride to avoid collisions; randomize start
+        let mut nonce: u32 = ((worker_id as u32) * worker_count as u32)
+            + (SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .unwrap_or_default()
+                .subsec_nanos() as u32
+                % 0xFFFF_0000);
 
         'mine: loop {
             // Swap job if a newer one arrives (no await)
@@ -313,32 +322,11 @@ async fn randomx_worker_loop(
                 let vm = create_vm_for_dataset(&cache, &dataset, None)?;
 
                 // Hash a batch
-                for _ in 0..1_000 {
+                for _ in 0..batch_size {
                     put_u32_le(&mut blob, 39, nonce); // Monero 32-bit nonce at offset 39
                     let digest = hash(&vm, &blob);
 
-                    // DEBUG: log the candidate details (enable with RUST_LOG=oxide_core=debug)
-                    {
-                        let le_hex = hex::encode(digest);
-                        let mut be_bytes = digest;
-                        be_bytes.reverse();
-                        let be_hex = hex::encode(be_bytes);
-                        let wrote_nonce =
-                            u32::from_le_bytes([blob[39], blob[40], blob[41], blob[42]]);
-
-                        tracing::debug!(
-                            job_id = %j.job_id,
-                            nonce = nonce,
-                            wrote_nonce = wrote_nonce,
-                            seed = %seed_hex,
-                            target = %j.target,
-                            hash_le = %le_hex,
-                            hash_be = %be_hex,
-                            "share_candidate_debug"
-                        );
-                    }
-
-                    if meets_target(&digest, &j.target) {
+                    if meets_target(&digest, &j) {
                         let _ = shares_tx.send(Share {
                             job_id: j.job_id.clone(),
                             nonce,
@@ -350,6 +338,18 @@ async fn randomx_worker_loop(
                             nonce,
                             job_id = %j.job_id,
                             "share candidate"
+                        );
+                    } else if tracing::enabled!(tracing::Level::DEBUG) && (nonce & 0x3ff == 0) {
+                        // Sample occasional hashes when debug logging is enabled
+                        let mut be_bytes = digest;
+                        be_bytes.reverse();
+                        tracing::debug!(
+                            job_id = %j.job_id,
+                            nonce = nonce,
+                            target = %j.target,
+                            hash_le = %hex::encode(digest),
+                            hash_be = %hex::encode(be_bytes),
+                            "share_candidate_debug",
                         );
                     }
 
@@ -368,59 +368,21 @@ fn put_u32_le(dst: &mut [u8], offset: usize, val: u32) {
     dst[offset..offset + 4].copy_from_slice(&val.to_le_bytes());
 }
 
-/// Monero Stratum "target" is usually a 32-bit LITTLE-endian hex (e.g., "f3220000" => 0x000022f3).
-/// Compare against the hash’s MSB 32 bits for a LE digest: i.e., the **last** 4 bytes.
-/// If a wider target (>8 hex chars) is provided, treat as a full 256-bit BE integer.
-fn meets_target(hash: &[u8; 32], target_hex: &str) -> bool {
-    // Fast path: 32-bit LE share target
-    if target_hex.len() <= 8 {
-        if let Ok(mut b) = hex::decode(target_hex) {
-            if b.len() > 4 {
-                b.truncate(4);
-            }
-            while b.len() < 4 {
-                b.push(0);
-            }
-            let t32 = u32::from_le_bytes([b[0], b[1], b[2], b[3]]);
-
-            // hash is LE; MSB 32 bits live in the last 4 bytes
-            let h_top_le32 = u32::from_le_bytes([hash[28], hash[29], hash[30], hash[31]]);
-            let ok = h_top_le32 <= t32;
-
-            tracing::debug!(
-                t_hex = %target_hex,
-                t32 = t32,
-                diff_est = (0x1_0000_0000u64 / (t32 as u64)),
-                h_top_le32 = h_top_le32,
-                ok_le = ok,
-                "share_check_32bit"
-            );
-
-            return ok;
-        }
-        return false;
+/// Check if hash meets the job's target using pre-parsed values.
+fn meets_target(hash: &[u8; 32], job: &PoolJob) -> bool {
+    if let Some(t32) = job.target_num {
+        let h_top_le32 = u32::from_le_bytes([hash[28], hash[29], hash[30], hash[31]]);
+        return h_top_le32 <= t32;
     }
-
-    // Wider target: treat as 256-bit BE and compare to the LE hash by reversing.
-    if let Ok(mut t) = hex::decode(target_hex) {
-        if t.is_empty() || t.len() > 32 {
-            return false;
-        }
-        if t.len() < 32 {
-            let mut pad = vec![0u8; 32 - t.len()]; // left-pad for BE
-            pad.extend_from_slice(&t);
-            t = pad;
-        }
-        // Compare as 256-bit BE: reverse LE hash into BE without allocation
+    if let Some(t) = job.target_wide {
         for (hb, tb) in hash.iter().rev().zip(t.iter()) {
             if hb != tb {
                 return *hb < *tb;
             }
         }
-        true
-    } else {
-        false
+        return true;
     }
+    false
 }
 
 #[cfg(test)]
@@ -432,7 +394,7 @@ mod tests {
     async fn spawns_correct_number_of_workers() {
         let (jobs_tx, _jobs_rx) = broadcast::channel(1);
         let (shares_tx, _shares_rx) = mpsc::unbounded_channel();
-        let handles = spawn_workers(3, jobs_tx, shares_tx, false, false);
+        let handles = spawn_workers(3, jobs_tx, shares_tx, false, false, 10_000);
         assert_eq!(handles.len(), 3);
         for h in handles {
             h.abort();
@@ -449,19 +411,47 @@ mod tests {
     #[test]
     fn meets_target_32bit() {
         let mut hash = [0u8; 32];
-        assert!(meets_target(&hash, "00000000"));
+        let mut job = PoolJob {
+            job_id: String::new(),
+            blob: String::new(),
+            target: "00000000".into(),
+            seed_hash: None,
+            height: None,
+            algo: None,
+            target_num: None,
+            target_wide: None,
+        };
+        job.compute_target();
+        assert!(meets_target(&hash, &job));
         hash[28] = 2; // h_top_le32 = 2
-        assert!(!meets_target(&hash, "01000000")); // target 1 (LE hex)
+        job.target = "01000000".into();
+        job.target_num = None;
+        job.target_wide = None;
+        job.compute_target();
+        assert!(!meets_target(&hash, &job)); // target 1 (LE hex)
     }
 
     #[test]
     fn meets_target_wide() {
         let hash_zero = [0u8; 32];
-        assert!(meets_target(&hash_zero, "01"));
+        let mut job = PoolJob {
+            job_id: String::new(),
+            blob: String::new(),
+            target: "01".into(),
+            seed_hash: None,
+            height: None,
+            algo: None,
+            target_num: None,
+            target_wide: None,
+        };
+        job.compute_target();
+        assert!(meets_target(&hash_zero, &job));
         let hash_high = [0xFFu8; 32];
-        assert!(!meets_target(&hash_high, "01"));
-        assert!(
-            meets_target(&hash_high, "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff")
-        );
+        assert!(!meets_target(&hash_high, &job));
+        job.target = "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff".into();
+        job.target_num = None;
+        job.target_wide = None;
+        job.compute_target();
+        assert!(meets_target(&hash_high, &job));
     }
 }

--- a/crates/oxide-miner/src/main.rs
+++ b/crates/oxide-miner/src/main.rs
@@ -8,7 +8,7 @@ use hyper::{Method, Request, Response};
 use hyper_util::rt::TokioIo;
 use oxide_core::worker::{Share, WorkItem};
 use oxide_core::{
-    cpu_has_aes, huge_pages_enabled, autotune_snapshot, spawn_workers, Config, DevFeeScheduler,
+    autotune_snapshot, cpu_has_aes, huge_pages_enabled, spawn_workers, Config, DevFeeScheduler,
     StratumClient, DEV_FEE_BASIS_POINTS, DEV_WALLET_ADDRESS,
 };
 use std::convert::Infallible;
@@ -65,6 +65,10 @@ struct Args {
     #[arg(long = "huge-pages")]
     huge_pages: bool,
 
+    /// Hashes computed per batch before yielding to the Tokio scheduler
+    #[arg(long = "batch-size", default_value_t = 10_000)]
+    batch_size: usize,
+
     /// Enable verbose debug logs; when set, also writes to ./logs/ (daily rotation)
     #[arg(long = "debug")]
     debug: bool,
@@ -72,7 +76,9 @@ struct Args {
 
 fn tiny_jitter_ms() -> u64 {
     // Derive a tiny jitter from the current time.
-    let now = SystemTime::now().duration_since(UNIX_EPOCH).unwrap_or_default();
+    let now = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default();
     let nanos = now.subsec_nanos() as u64;
     100 + (nanos % 500) // 100...600 ms
 }
@@ -137,6 +143,7 @@ async fn main() -> Result<()> {
         api_port: args.api_port,
         affinity: args.affinity,
         huge_pages: args.huge_pages,
+        batch_size: args.batch_size,
         agent: format!("OxideMiner/{}", env!("CARGO_PKG_VERSION")),
     };
 
@@ -203,6 +210,7 @@ async fn main() -> Result<()> {
         shares_tx,
         cfg.affinity,
         large_pages,
+        cfg.batch_size,
     );
 
     let main_pool = cfg.pool.clone();
@@ -292,7 +300,8 @@ async fn main() -> Result<()> {
                                                 Err(e) => warn!("devfee connect failed: {e}"),
                                             }
                                         } else if let Some(params) = v.get("params") {
-                                            if let Ok(job) = serde_json::from_value::<oxide_core::stratum::PoolJob>(params.clone()) {
+                                            if let Ok(mut job) = serde_json::from_value::<oxide_core::stratum::PoolJob>(params.clone()) {
+                                                job.compute_target();
                                                 let _ = jobs_tx.send(WorkItem { job, is_devfee: using_dev });
                                             }
                                         }


### PR DESCRIPTION
## Summary
- remove per-hash logging and parse job targets once
- make hash batch size configurable and randomize worker nonces
- tune system heuristics and use buffered pool IO

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68bd91b4f71883339373b731ca422413