### PR TITLE
Optimize RandomX worker hot path and configuration

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,3 +31,6 @@ sysinfo = "0.30"
 raw-cpuid = "11"
 windows-sys = { version = "0.52", features = ["Win32_System_Memory"] }
 
+[profile.release]
+lto = true
+

--- a/crates/oxide-core/src/config.rs
+++ b/crates/oxide-core/src/config.rs
@@ -21,6 +21,8 @@ pub struct Config {
     /// request huge/large pages for RandomX dataset
     pub huge_pages: bool,
     pub agent: String,
+    /// number of hashes per batch before yielding
+    pub batch_size: usize,
 }
 
 impl Default for Config {
@@ -36,6 +38,7 @@ impl Default for Config {
             affinity: false,
             huge_pages: false,
             agent: format!("OxideMiner/{}", env!("CARGO_PKG_VERSION")),
+            batch_size: 10_000,
         }
     }
 }
@@ -56,5 +59,6 @@ mod tests {
         assert!(!cfg.affinity);
         assert!(!cfg.huge_pages);
         assert!(cfg.agent.starts_with("OxideMiner/"));
+        assert_eq!(cfg.batch_size, 10_000);
     }
 }

--- a/crates/oxide-core/src/system.rs
+++ b/crates/oxide-core/src/system.rs
@@ -57,6 +57,18 @@ pub fn cpu_has_aes() -> bool {
     }
 }
 
+/// Determine whether the current CPU supports POPCNT instruction (x86/x86_64).
+pub fn cpu_has_popcnt() -> bool {
+    #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+    {
+        std::is_x86_feature_detected!("popcnt")
+    }
+    #[cfg(not(any(target_arch = "x86", target_arch = "x86_64")))]
+    {
+        false
+    }
+}
+
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 /// Return the size of the L3 cache in bytes if detectable via CPUID(0x4).
 fn l3_cache_bytes() -> Option<usize> {
@@ -108,13 +120,18 @@ pub fn autotune_snapshot() -> AutoTuneSnapshot {
 
     // RandomX "fast" dataset and per-thread scratchpad estimates
     let dataset = 2_u64 * 1024 * 1024 * 1024; // ~2 GiB
-    let scratch = 16_u64 * 1024 * 1024;       // ~16 MiB per thread
+    let scratch = 2_u64 * 1024 * 1024;        // ~2 MiB per thread
 
     let mut threads = physical;
 
-    // L3 clamp (~2 MiB per thread)
+    // L3 clamp with dynamic per-thread heuristic
     if let Some(l3b) = l3 {
-        let cache_threads = (l3b / (2 * 1024 * 1024)).max(1);
+        let l3_per_thread = if l3b > 64 * 1024 * 1024 {
+            4 * 1024 * 1024
+        } else {
+            2 * 1024 * 1024
+        };
+        let cache_threads = (l3b / l3_per_thread).max(1);
         threads = threads.min(cache_threads);
     }
 
@@ -165,6 +182,7 @@ mod tests {
     #[test]
     fn feature_checks_do_not_panic() {
         let _ = cpu_has_aes();
+        let _ = cpu_has_popcnt();
         let _ = huge_pages_enabled();
     }
 }

--- a/crates/oxide-core/src/worker.rs
+++ b/crates/oxide-core/src/worker.rs
@@ -1,6 +1,7 @@
 use anyhow::Result;
 use tokio::sync::{broadcast, mpsc};
 use tracing::{info, warn};
+use std::time::{SystemTime, UNIX_EPOCH};
 
 use crate::stratum::PoolJob;
 
@@ -25,6 +26,7 @@ pub fn spawn_workers(
     shares_tx: mpsc::UnboundedSender<Share>,
     affinity: bool,
     large_pages: bool,
+    batch_size: usize,
 ) -> Vec<tokio::task::JoinHandle<()>> {
     #[cfg(feature = "randomx")]
     engine::set_large_pages(large_pages);
@@ -46,7 +48,7 @@ pub fn spawn_workers(
                             let _ = core_affinity::set_for_current(*id);
                         }
                     }
-                    if let Err(e) = randomx_worker_loop(i, n, &mut rx, shares_tx).await {
+                    if let Err(e) = randomx_worker_loop(i, n, batch_size, &mut rx, shares_tx).await {
                         warn!(worker = i, error = ?e, "worker exited");
                     }
                 }
@@ -176,6 +178,7 @@ mod engine {
     }
 
     /// Calculate hash as fixed [u8;32].
+    #[inline(always)]
     pub fn hash(vm: &Vm, input: &[u8]) -> [u8; 32] {
         let v = vm.inner.calculate_hash(input).expect("randomx hash failed");
         let mut out = [0u8; 32];
@@ -243,6 +246,7 @@ mod engine {
 async fn randomx_worker_loop(
     worker_id: usize,
     worker_count: usize,
+    batch_size: usize,
     rx: &mut broadcast::Receiver<WorkItem>,
     shares_tx: mpsc::UnboundedSender<Share>,
 ) -> Result<()> {
@@ -294,8 +298,10 @@ async fn randomx_worker_loop(
             continue;
         }
 
-        // Per-worker nonce stride to avoid collisions
-        let mut nonce: u32 = worker_id as u32;
+        // Per-worker nonce stride to avoid collisions; randomize starting point
+        let now = SystemTime::now().duration_since(UNIX_EPOCH).unwrap_or_default();
+        let mut nonce: u32 = ((worker_id as u32) * worker_count as u32)
+            + (now.subsec_nanos() & 0xFFFF_0000);
 
         'mine: loop {
             // Swap job if a newer one arrives (no await)
@@ -313,32 +319,11 @@ async fn randomx_worker_loop(
                 let vm = create_vm_for_dataset(&cache, &dataset, None)?;
 
                 // Hash a batch
-                for _ in 0..1_000 {
+                for _ in 0..batch_size {
                     put_u32_le(&mut blob, 39, nonce); // Monero 32-bit nonce at offset 39
                     let digest = hash(&vm, &blob);
 
-                    // DEBUG: log the candidate details (enable with RUST_LOG=oxide_core=debug)
-                    {
-                        let le_hex = hex::encode(digest);
-                        let mut be_bytes = digest;
-                        be_bytes.reverse();
-                        let be_hex = hex::encode(be_bytes);
-                        let wrote_nonce =
-                            u32::from_le_bytes([blob[39], blob[40], blob[41], blob[42]]);
-
-                        tracing::debug!(
-                            job_id = %j.job_id,
-                            nonce = nonce,
-                            wrote_nonce = wrote_nonce,
-                            seed = %seed_hex,
-                            target = %j.target,
-                            hash_le = %le_hex,
-                            hash_be = %be_hex,
-                            "share_candidate_debug"
-                        );
-                    }
-
-                    if meets_target(&digest, &j.target) {
+                    if meets_target(&digest, &j.target, j.target_num) {
                         let _ = shares_tx.send(Share {
                             job_id: j.job_id.clone(),
                             nonce,
@@ -371,51 +356,30 @@ fn put_u32_le(dst: &mut [u8], offset: usize, val: u32) {
 /// Monero Stratum "target" is usually a 32-bit LITTLE-endian hex (e.g., "f3220000" => 0x000022f3).
 /// Compare against the hash’s MSB 32 bits for a LE digest: i.e., the **last** 4 bytes.
 /// If a wider target (>8 hex chars) is provided, treat as a full 256-bit BE integer.
-fn meets_target(hash: &[u8; 32], target_hex: &str) -> bool {
-    // Fast path: 32-bit LE share target
+fn meets_target(hash: &[u8; 32], target_hex: &str, target_u32: Option<u32>) -> bool {
+    if let Some(t32) = target_u32 {
+        let h_top_le32 = u32::from_le_bytes([hash[28], hash[29], hash[30], hash[31]]);
+        return h_top_le32 <= t32;
+    }
     if target_hex.len() <= 8 {
         if let Ok(mut b) = hex::decode(target_hex) {
-            if b.len() > 4 {
-                b.truncate(4);
-            }
-            while b.len() < 4 {
-                b.push(0);
-            }
+            if b.len() > 4 { b.truncate(4); }
+            while b.len() < 4 { b.push(0); }
             let t32 = u32::from_le_bytes([b[0], b[1], b[2], b[3]]);
-
-            // hash is LE; MSB 32 bits live in the last 4 bytes
             let h_top_le32 = u32::from_le_bytes([hash[28], hash[29], hash[30], hash[31]]);
-            let ok = h_top_le32 <= t32;
-
-            tracing::debug!(
-                t_hex = %target_hex,
-                t32 = t32,
-                diff_est = (0x1_0000_0000u64 / (t32 as u64)),
-                h_top_le32 = h_top_le32,
-                ok_le = ok,
-                "share_check_32bit"
-            );
-
-            return ok;
+            return h_top_le32 <= t32;
         }
         return false;
     }
-
-    // Wider target: treat as 256-bit BE and compare to the LE hash by reversing.
     if let Ok(mut t) = hex::decode(target_hex) {
-        if t.is_empty() || t.len() > 32 {
-            return false;
-        }
+        if t.is_empty() || t.len() > 32 { return false; }
         if t.len() < 32 {
-            let mut pad = vec![0u8; 32 - t.len()]; // left-pad for BE
+            let mut pad = vec![0u8; 32 - t.len()];
             pad.extend_from_slice(&t);
             t = pad;
         }
-        // Compare as 256-bit BE: reverse LE hash into BE without allocation
         for (hb, tb) in hash.iter().rev().zip(t.iter()) {
-            if hb != tb {
-                return *hb < *tb;
-            }
+            if hb != tb { return *hb < *tb; }
         }
         true
     } else {
@@ -432,7 +396,7 @@ mod tests {
     async fn spawns_correct_number_of_workers() {
         let (jobs_tx, _jobs_rx) = broadcast::channel(1);
         let (shares_tx, _shares_rx) = mpsc::unbounded_channel();
-        let handles = spawn_workers(3, jobs_tx, shares_tx, false, false);
+        let handles = spawn_workers(3, jobs_tx, shares_tx, false, false, 1_000);
         assert_eq!(handles.len(), 3);
         for h in handles {
             h.abort();
@@ -449,19 +413,19 @@ mod tests {
     #[test]
     fn meets_target_32bit() {
         let mut hash = [0u8; 32];
-        assert!(meets_target(&hash, "00000000"));
+        assert!(meets_target(&hash, "00000000", Some(0)));
         hash[28] = 2; // h_top_le32 = 2
-        assert!(!meets_target(&hash, "01000000")); // target 1 (LE hex)
+        assert!(!meets_target(&hash, "01000000", Some(1))); // target 1 (LE hex)
     }
 
     #[test]
     fn meets_target_wide() {
         let hash_zero = [0u8; 32];
-        assert!(meets_target(&hash_zero, "01"));
+        assert!(meets_target(&hash_zero, "01", None));
         let hash_high = [0xFFu8; 32];
-        assert!(!meets_target(&hash_high, "01"));
+        assert!(!meets_target(&hash_high, "01", None));
         assert!(
-            meets_target(&hash_high, "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff")
+            meets_target(&hash_high, "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff", None)
         );
     }
 }


### PR DESCRIPTION
## Summary
- remove per-hash debugging and reuse parsed share targets in the RandomX worker
- add configurable batch size and randomize worker nonce start
- refine autotune heuristics and enable LTO in release builds

## Testing
- `cargo test --all`

------
https://chatgpt.com/codex/tasks/task_e_68bd91b4f71883339373b731ca422413