### PR TITLE
Add expanded metrics API and dashboard

### DIFF
--- a/crates/oxide-core/src/worker.rs
+++ b/crates/oxide-core/src/worker.rs
@@ -1,4 +1,5 @@
 use anyhow::Result;
+use std::sync::{Arc, atomic::{AtomicU64, Ordering}};
 use std::time::{SystemTime, UNIX_EPOCH};
 use tokio::sync::{broadcast, mpsc};
 use tracing::{info, warn};
@@ -28,6 +29,7 @@ pub fn spawn_workers(
     large_pages: bool,
     batch_size: usize,
     yield_between_batches: bool,
+    hash_counter: Arc<AtomicU64>,
 ) -> Vec<tokio::task::JoinHandle<()>> {
     #[cfg(feature = "randomx")]
     engine::set_large_pages(large_pages);
@@ -41,6 +43,7 @@ pub fn spawn_workers(
             let mut rx = jobs_tx.subscribe();
             let shares_tx = shares_tx.clone();
             let core_ids = core_ids.clone();
+            let hc = hash_counter.clone();
             tokio::spawn(async move {
                 #[cfg(feature = "randomx")]
                 {
@@ -56,6 +59,7 @@ pub fn spawn_workers(
                         yield_between_batches,
                         &mut rx,
                         shares_tx,
+                        hc,
                     )
                     .await
                     {
@@ -265,6 +269,7 @@ async fn randomx_worker_loop(
     yield_between_batches: bool,
     rx: &mut broadcast::Receiver<WorkItem>,
     shares_tx: mpsc::UnboundedSender<Share>,
+    hash_counter: Arc<AtomicU64>,
 ) -> Result<()> {
     use engine::*;
 
@@ -338,9 +343,11 @@ async fn randomx_worker_loop(
             let mut need_yield = false;
             {
                 let vm = vm_ref;
+                let mut local_hashes: u64 = 0;
                 for i in 0..batch_size {
                     put_u32_le(&mut blob, 39, nonce);
                     let digest = hash(vm, &blob);
+                    local_hashes += 1;
                     if meets_target(&digest, &j) {
                         let le_hex = hex::encode(digest);
                         let mut be_bytes = digest;
@@ -375,6 +382,7 @@ async fn randomx_worker_loop(
                         break; // exit early to yield outside borrow scope
                     }
                 }
+                hash_counter.fetch_add(local_hashes, Ordering::Relaxed);
             }
             if need_yield || yield_between_batches {
                 tokio::task::yield_now().await;
@@ -437,12 +445,14 @@ fn meets_target(hash: &[u8; 32], job: &PoolJob) -> bool {
 mod tests {
     use super::*;
     use tokio::sync::{broadcast, mpsc};
+    use std::sync::{Arc, atomic::AtomicU64};
 
     #[tokio::test]
     async fn spawns_correct_number_of_workers() {
         let (jobs_tx, _jobs_rx) = broadcast::channel(1);
         let (shares_tx, _shares_rx) = mpsc::unbounded_channel();
-        let handles = spawn_workers(3, jobs_tx, shares_tx, false, false, 10_000, true);
+        let hash_counter = Arc::new(AtomicU64::new(0));
+        let handles = spawn_workers(3, jobs_tx, shares_tx, false, false, 10_000, true, hash_counter);
         assert_eq!(handles.len(), 3);
         for h in handles {
             h.abort();

--- a/crates/oxide-miner/src/http_api.rs
+++ b/crates/oxide-miner/src/http_api.rs
@@ -1,19 +1,23 @@
+use crate::stats::Stats;
 use http_body_util::Full;
 use hyper::body::{Bytes, Incoming};
 use hyper::server::conn::http1;
 use hyper::service::service_fn;
-use hyper::{Method, Request, Response};
+use hyper::{header, Method, Request, Response};
 use hyper_util::rt::TokioIo;
+use serde_json::json;
 use std::convert::Infallible;
 use std::net::SocketAddr;
-use std::sync::{
-    atomic::{AtomicU64, Ordering},
-    Arc,
-};
+use std::sync::{atomic::Ordering, Arc};
 use tokio::net::TcpListener;
 use tracing::info;
 
-pub async fn run_http_api(port: u16, accepted: Arc<AtomicU64>, rejected: Arc<AtomicU64>) {
+const DASHBOARD_HTML: &str = r#"<!DOCTYPE html><html><body><pre id='stats'></pre><script>
+async function update(){const r=await fetch('/api/stats');const j=await r.json();document.getElementById('stats').textContent=JSON.stringify(j,null,2);}
+setInterval(update,1000);update();
+</script></body></html>"#;
+
+pub async fn run_http_api(port: u16, stats: Arc<Stats>) {
     let addr = SocketAddr::from(([127, 0, 0, 1], port));
     let listener = match TcpListener::bind(addr).await {
         Ok(v) => v,
@@ -33,29 +37,74 @@ pub async fn run_http_api(port: u16, accepted: Arc<AtomicU64>, rejected: Arc<Ato
             }
         };
         let io = TokioIo::new(stream);
-        let a = accepted.clone();
-        let r = rejected.clone();
+        let s = stats.clone();
 
         tokio::spawn(async move {
             let svc = service_fn(move |req: Request<Incoming>| {
-                let a = a.clone();
-                let r = r.clone();
+                let s = s.clone();
 
                 async move {
-                    if req.method() == Method::GET && req.uri().path() == "/metrics" {
-                        let body = format!(
-                            "{{\"accepted\":{},\"rejected\":{}}}",
-                            a.load(Ordering::Relaxed),
-                            r.load(Ordering::Relaxed)
-                        );
-                        Ok::<_, Infallible>(Response::new(Full::new(Bytes::from(body))))
-                    } else {
-                        Ok::<_, Infallible>(
-                            Response::builder()
-                                .status(404)
-                                .body(Full::new(Bytes::from("not found")))
-                                .unwrap(),
-                        )
+                    match (req.method(), req.uri().path()) {
+                        (&Method::GET, "/metrics") => {
+                            let mut body = String::new();
+                            let accepted = s.accepted.load(Ordering::Relaxed);
+                            let rejected = s.rejected.load(Ordering::Relaxed);
+                            let dev_acc = s.dev_accepted.load(Ordering::Relaxed);
+                            let dev_rej = s.dev_rejected.load(Ordering::Relaxed);
+                            let hashes = s.hashes.load(Ordering::Relaxed);
+                            let hashrate = s.hashrate();
+                            let connected = if s.pool_connected.load(Ordering::Relaxed) {1} else {0};
+                            let tls = if s.tls {1} else {0};
+                            use std::fmt::Write;
+                            writeln!(body, "oxide_hashes_total {}", hashes).ok();
+                            writeln!(body, "oxide_hashrate {}", hashrate).ok();
+                            writeln!(body, "oxide_shares_accepted_total {}", accepted).ok();
+                            writeln!(body, "oxide_shares_rejected_total {}", rejected).ok();
+                            writeln!(body, "oxide_devfee_shares_accepted_total {}", dev_acc).ok();
+                            writeln!(body, "oxide_devfee_shares_rejected_total {}", dev_rej).ok();
+                            writeln!(body, "oxide_pool_connected {}", connected).ok();
+                            writeln!(body, "oxide_tls_enabled {}", tls).ok();
+                            let mut resp = Response::new(Full::new(Bytes::from(body)));
+                            resp.headers_mut().insert(header::CONTENT_TYPE, header::HeaderValue::from_static("text/plain"));
+                            Ok::<_, Infallible>(resp)
+                        }
+                        (&Method::GET, "/api/stats") => {
+                            let accepted = s.accepted.load(Ordering::Relaxed);
+                            let rejected = s.rejected.load(Ordering::Relaxed);
+                            let dev_acc = s.dev_accepted.load(Ordering::Relaxed);
+                            let dev_rej = s.dev_rejected.load(Ordering::Relaxed);
+                            let hashes = s.hashes.load(Ordering::Relaxed);
+                            let hashrate = s.hashrate();
+                            let resp_body = json!({
+                                "hashrate": hashrate,
+                                "hashes_total": hashes,
+                                "pool": s.pool,
+                                "connected": s.pool_connected.load(Ordering::Relaxed),
+                                "tls": s.tls,
+                                "shares": {
+                                    "accepted": accepted,
+                                    "rejected": rejected,
+                                    "dev_accepted": dev_acc,
+                                    "dev_rejected": dev_rej,
+                                }
+                            }).to_string();
+                            let mut resp = Response::new(Full::new(Bytes::from(resp_body)));
+                            resp.headers_mut().insert(header::CONTENT_TYPE, header::HeaderValue::from_static("application/json"));
+                            Ok::<_, Infallible>(resp)
+                        }
+                        (&Method::GET, "/") => {
+                            let mut resp = Response::new(Full::new(Bytes::from_static(DASHBOARD_HTML.as_bytes())));
+                            resp.headers_mut().insert(header::CONTENT_TYPE, header::HeaderValue::from_static("text/html"));
+                            Ok::<_, Infallible>(resp)
+                        }
+                        _ => {
+                            Ok::<_, Infallible>(
+                                Response::builder()
+                                    .status(404)
+                                    .body(Full::new(Bytes::from("not found")))
+                                    .unwrap(),
+                            )
+                        }
                     }
                 }
             });
@@ -70,30 +119,45 @@ pub async fn run_http_api(port: u16, accepted: Arc<AtomicU64>, rejected: Arc<Ato
 #[cfg(test)]
 mod tests {
     use super::run_http_api;
+    use crate::stats::Stats;
     use reqwest::Client;
-    use std::sync::{atomic::AtomicU64, Arc};
+    use std::sync::Arc;
+    use std::sync::atomic::Ordering;
     use tokio::time::{sleep, Duration};
 
     #[tokio::test]
-    async fn metrics_endpoint_reports_counts() {
+    async fn endpoints_report_stats() {
         // Pick an available port by binding to port 0 first.
         let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
         let port = listener.local_addr().unwrap().port();
         drop(listener);
 
-        let accepted = Arc::new(AtomicU64::new(5));
-        let rejected = Arc::new(AtomicU64::new(2));
+        let stats = Arc::new(Stats::new("pool".into(), false));
+        stats.accepted.store(5, Ordering::Relaxed);
+        stats.rejected.store(2, Ordering::Relaxed);
+        stats.dev_accepted.store(1, Ordering::Relaxed);
+        stats.hashes.store(100, Ordering::Relaxed);
 
-        let server = tokio::spawn(run_http_api(port, accepted.clone(), rejected.clone()));
+        let server = tokio::spawn(run_http_api(port, stats.clone()));
         // Give the server a moment to start
         sleep(Duration::from_millis(50)).await;
 
         let client = Client::new();
+        let url = format!("http://127.0.0.1:{}/api/stats", port);
+        let resp = client.get(url).send().await.unwrap();
+        assert!(resp.status().is_success());
+        let text = resp.text().await.unwrap();
+        let body: serde_json::Value = serde_json::from_str(&text).unwrap();
+        assert_eq!(body["shares"]["accepted"], 5);
+        assert_eq!(body["shares"]["rejected"], 2);
+        assert_eq!(body["shares"]["dev_accepted"], 1);
+
         let url = format!("http://127.0.0.1:{}/metrics", port);
         let resp = client.get(url).send().await.unwrap();
         assert!(resp.status().is_success());
-        let body = resp.text().await.unwrap();
-        assert_eq!(body, "{\"accepted\":5,\"rejected\":2}");
+        let text = resp.text().await.unwrap();
+        assert!(text.contains("oxide_shares_accepted_total 5"));
+        assert!(text.contains("oxide_devfee_shares_accepted_total 1"));
 
         server.abort();
     }

--- a/crates/oxide-miner/src/main.rs
+++ b/crates/oxide-miner/src/main.rs
@@ -2,6 +2,7 @@ mod args;
 mod http_api;
 mod miner;
 mod util;
+mod stats;
 
 use anyhow::Result;
 use args::Args;

--- a/crates/oxide-miner/src/stats.rs
+++ b/crates/oxide-miner/src/stats.rs
@@ -1,0 +1,43 @@
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::Arc;
+use std::time::Instant;
+
+/// Shared miner statistics updated across tasks and exposed via the HTTP API.
+pub struct Stats {
+    pub start: Instant,
+    pub accepted: AtomicU64,
+    pub rejected: AtomicU64,
+    pub dev_accepted: AtomicU64,
+    pub dev_rejected: AtomicU64,
+    /// Total hashes computed since startup.
+    pub hashes: Arc<AtomicU64>,
+    pub pool_connected: AtomicBool,
+    pub tls: bool,
+    pub pool: String,
+}
+
+impl Stats {
+    pub fn new(pool: String, tls: bool) -> Self {
+        Self {
+            start: Instant::now(),
+            accepted: AtomicU64::new(0),
+            rejected: AtomicU64::new(0),
+            dev_accepted: AtomicU64::new(0),
+            dev_rejected: AtomicU64::new(0),
+            hashes: Arc::new(AtomicU64::new(0)),
+            pool_connected: AtomicBool::new(false),
+            tls,
+            pool,
+        }
+    }
+
+    /// Average hashes per second since startup.
+    pub fn hashrate(&self) -> f64 {
+        let elapsed = self.start.elapsed().as_secs_f64();
+        if elapsed > 0.0 {
+            self.hashes.load(Ordering::Relaxed) as f64 / elapsed
+        } else {
+            0.0
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- provide shared `Stats` structure to track hashes, shares, devfee activity, TLS and pool status
- expand HTTP API with Prometheus `/metrics`, JSON `/api/stats`, and a tiny HTML dashboard
- count hashes in workers and report devfee share stats

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68c5b26a09bc83338f00b53b1f5de3ca