### PR TITLE
Add metrics dashboard and enhanced API

### DIFF
--- a/crates/oxide-miner/Cargo.toml
+++ b/crates/oxide-miner/Cargo.toml
@@ -15,9 +15,9 @@ tracing-subscriber = { workspace = true }
 num_cpus = { workspace = true }
 hex = { workspace = true }
 serde_json = { workspace = true }
-hyper = { workspace = true }
-hyper-util = { workspace = true }
-http-body-util = { workspace = true }
+axum = { version = "0.7", features = ["macros", "json"] }
+tokio-stream = "0.1"
+serde = { workspace = true }
 tracing-appender = "0.2"
 
 [dev-dependencies]

--- a/crates/oxide-miner/src/http_api.rs
+++ b/crates/oxide-miner/src/http_api.rs
@@ -1,91 +1,202 @@
-use http_body_util::Full;
-use hyper::body::{Bytes, Incoming};
-use hyper::server::conn::http1;
-use hyper::service::service_fn;
-use hyper::{Method, Request, Response};
-use hyper_util::rt::TokioIo;
-use std::convert::Infallible;
-use std::net::SocketAddr;
-use std::sync::{
-    atomic::{AtomicU64, Ordering},
-    Arc,
+use axum::{
+    extract::State,
+    response::{sse::Event, Html, Sse},
+    routing::get,
+    Json, Router,
 };
-use tokio::net::TcpListener;
+use tokio_stream::Stream;
+use std::{
+    convert::Infallible,
+    net::SocketAddr,
+    sync::{
+        atomic::{AtomicBool, AtomicU64, Ordering},
+        Arc,
+    },
+    time::{Duration, Instant},
+};
+use tokio_stream::{wrappers::IntervalStream, StreamExt};
 use tracing::info;
 
-pub async fn run_http_api(port: u16, accepted: Arc<AtomicU64>, rejected: Arc<AtomicU64>) {
+/// Shared state for the HTTP API.
+pub struct ApiState {
+    pub accepted: Arc<AtomicU64>,
+    pub rejected: Arc<AtomicU64>,
+    pub devfee_accepted: Arc<AtomicU64>,
+    pub devfee_rejected: Arc<AtomicU64>,
+    pub hashes: Arc<AtomicU64>,
+    pub connected: Arc<AtomicBool>,
+    pub start: Instant,
+    pub pool: String,
+    pub tls: bool,
+}
+
+#[derive(serde::Serialize)]
+struct Stats {
+    hashrate: f64,
+    pool: String,
+    tls: bool,
+    connected: bool,
+    shares_accepted: u64,
+    shares_rejected: u64,
+    devfee_accepted: u64,
+    devfee_rejected: u64,
+}
+
+fn gather(state: &ApiState) -> Stats {
+    let elapsed = state.start.elapsed().as_secs_f64().max(1.0);
+    let hashes = state.hashes.load(Ordering::Relaxed) as f64;
+    Stats {
+        hashrate: hashes / elapsed,
+        pool: state.pool.clone(),
+        tls: state.tls,
+        connected: state.connected.load(Ordering::Relaxed),
+        shares_accepted: state.accepted.load(Ordering::Relaxed),
+        shares_rejected: state.rejected.load(Ordering::Relaxed),
+        devfee_accepted: state.devfee_accepted.load(Ordering::Relaxed),
+        devfee_rejected: state.devfee_rejected.load(Ordering::Relaxed),
+    }
+}
+
+async fn stats(State(state): State<Arc<ApiState>>) -> Json<Stats> {
+    Json(gather(&state))
+}
+
+async fn metrics(State(state): State<Arc<ApiState>>) -> String {
+    let s = gather(&state);
+    format!(
+        concat!(
+            "oxide_hashrate {}\n",
+            "oxide_accepted_total {}\n",
+            "oxide_rejected_total {}\n",
+            "oxide_devfee_accepted_total {}\n",
+            "oxide_devfee_rejected_total {}\n",
+            "oxide_connected {}\n",
+        ),
+        s.hashrate,
+        s.shares_accepted,
+        s.shares_rejected,
+        s.devfee_accepted,
+        s.devfee_rejected,
+        if s.connected { 1 } else { 0 },
+    )
+}
+
+async fn dashboard() -> Html<&'static str> {
+    // Very small dashboard that polls /api/stats every 2s
+    const DASHBOARD: &str = r#"<!DOCTYPE html>
+<html><head><title>OxideMiner</title></head>
+<body><h1>OxideMiner</h1><pre id="stats">loading...</pre>
+<script>
+async function refresh(){
+  const r = await fetch('/api/stats');
+  const s = await r.json();
+  document.getElementById('stats').textContent =
+    `hashrate: ${s.hashrate.toFixed(2)} H/s\n` +
+    `pool: ${s.pool} (tls: ${s.tls})\n` +
+    `connected: ${s.connected}\n` +
+    `accepted: ${s.shares_accepted} rejected: ${s.shares_rejected}\n` +
+    `devfee accepted: ${s.devfee_accepted} devfee rejected: ${s.devfee_rejected}`;
+}
+setInterval(refresh,2000);refresh();
+</script></body></html>"#;
+    Html(DASHBOARD)
+}
+
+async fn events(State(state): State<Arc<ApiState>>) -> Sse<impl Stream<Item = Result<Event, Infallible>>> {
+    let stream = IntervalStream::new(tokio::time::interval(Duration::from_secs(1))).map(move |_| {
+        let data = serde_json::to_string(&gather(&state)).unwrap();
+        Ok::<_, Infallible>(Event::default().data(data))
+    });
+    Sse::new(stream)
+}
+
+pub async fn run_http_api(port: u16, state: Arc<ApiState>) {
+    let app = Router::new()
+        .route("/", get(dashboard))
+        .route("/api/stats", get(stats))
+        .route("/metrics", get(metrics))
+        .route("/events", get(events))
+        .with_state(state);
+
     let addr = SocketAddr::from(([127, 0, 0, 1], port));
-    let listener = match TcpListener::bind(addr).await {
+    info!("HTTP API listening on http://{addr}");
+    let listener = match tokio::net::TcpListener::bind(addr).await {
         Ok(v) => v,
         Err(e) => {
             eprintln!("HTTP bind failed: {e}");
             return;
         }
     };
-    info!("HTTP API listening on http://{addr}");
 
-    loop {
-        let (stream, _peer) = match listener.accept().await {
-            Ok(v) => v,
-            Err(e) => {
-                eprintln!("HTTP accept error: {e}");
-                continue;
-            }
-        };
-        let io = TokioIo::new(stream);
-        let a = accepted.clone();
-        let r = rejected.clone();
-
-        tokio::spawn(async move {
-            let svc = service_fn(move |req: Request<Incoming>| {
-                let a = a.clone();
-                let r = r.clone();
-
-                async move {
-                    if req.method() == Method::GET && req.uri().path() == "/metrics" {
-                        let body = format!(
-                            "{{\"accepted\":{},\"rejected\":{}}}",
-                            a.load(Ordering::Relaxed),
-                            r.load(Ordering::Relaxed)
-                        );
-                        Ok::<_, Infallible>(Response::new(Full::new(Bytes::from(body))))
-                    } else {
-                        Ok::<_, Infallible>(
-                            Response::builder()
-                                .status(404)
-                                .body(Full::new(Bytes::from("not found")))
-                                .unwrap(),
-                        )
-                    }
-                }
-            });
-
-            if let Err(err) = http1::Builder::new().serve_connection(io, svc).await {
-                eprintln!("http connection error: {err}");
-            }
-        });
+    if let Err(e) = axum::serve(listener, app).await {
+        eprintln!("HTTP server error: {e}");
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use super::run_http_api;
+    use super::{run_http_api, ApiState};
     use reqwest::Client;
-    use std::sync::{atomic::AtomicU64, Arc};
+    use std::sync::{atomic::{AtomicBool, AtomicU64}, Arc};
+    use std::time::Instant;
     use tokio::time::{sleep, Duration};
 
     #[tokio::test]
-    async fn metrics_endpoint_reports_counts() {
+    async fn stats_endpoint_reports_counts() {
         // Pick an available port by binding to port 0 first.
         let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
         let port = listener.local_addr().unwrap().port();
         drop(listener);
 
-        let accepted = Arc::new(AtomicU64::new(5));
-        let rejected = Arc::new(AtomicU64::new(2));
+        let state = ApiState {
+            accepted: Arc::new(AtomicU64::new(5)),
+            rejected: Arc::new(AtomicU64::new(2)),
+            devfee_accepted: Arc::new(AtomicU64::new(1)),
+            devfee_rejected: Arc::new(AtomicU64::new(0)),
+            hashes: Arc::new(AtomicU64::new(0)),
+            connected: Arc::new(AtomicBool::new(true)),
+            start: Instant::now(),
+            pool: "pool".into(),
+            tls: false,
+        };
+        let state = Arc::new(state);
 
-        let server = tokio::spawn(run_http_api(port, accepted.clone(), rejected.clone()));
+        let server = tokio::spawn(run_http_api(port, state.clone()));
         // Give the server a moment to start
+        sleep(Duration::from_millis(50)).await;
+
+        let client = Client::new();
+        let url = format!("http://127.0.0.1:{}/api/stats", port);
+        let resp = client.get(url).send().await.unwrap();
+        assert!(resp.status().is_success());
+        let text = resp.text().await.unwrap();
+        let body: serde_json::Value = serde_json::from_str(&text).unwrap();
+        assert_eq!(body["shares_accepted"], 5);
+        assert_eq!(body["shares_rejected"], 2);
+
+        server.abort();
+    }
+
+    #[tokio::test]
+    async fn metrics_endpoint_reports_text() {
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let port = listener.local_addr().unwrap().port();
+        drop(listener);
+
+        let state = ApiState {
+            accepted: Arc::new(AtomicU64::new(5)),
+            rejected: Arc::new(AtomicU64::new(2)),
+            devfee_accepted: Arc::new(AtomicU64::new(1)),
+            devfee_rejected: Arc::new(AtomicU64::new(0)),
+            hashes: Arc::new(AtomicU64::new(0)),
+            connected: Arc::new(AtomicBool::new(true)),
+            start: Instant::now(),
+            pool: "pool".into(),
+            tls: false,
+        };
+        let state = Arc::new(state);
+
+        let server = tokio::spawn(run_http_api(port, state.clone()));
         sleep(Duration::from_millis(50)).await;
 
         let client = Client::new();
@@ -93,8 +204,9 @@ mod tests {
         let resp = client.get(url).send().await.unwrap();
         assert!(resp.status().is_success());
         let body = resp.text().await.unwrap();
-        assert_eq!(body, "{\"accepted\":5,\"rejected\":2}");
+        assert!(body.contains("oxide_accepted_total 5"));
 
         server.abort();
     }
 }
+


### PR DESCRIPTION
## Summary
- add HTTP API with Prometheus metrics, JSON stats, SSE updates, and a tiny dashboard
- track hash rate and devfee share counts across miners
- expose metrics for pool connection and share acceptance

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68c5b26a09bc83338f00b53b1f5de3ca