### PR TITLE
feat: expand http metrics api

### DIFF
--- a/crates/oxide-miner/Cargo.toml
+++ b/crates/oxide-miner/Cargo.toml
@@ -19,6 +19,9 @@ hyper = { workspace = true }
 hyper-util = { workspace = true }
 http-body-util = { workspace = true }
 tracing-appender = "0.2"
+axum = { version = "0.7", features = ["macros"] }
+tokio-stream = "0.1"
+serde = { workspace = true }
 
 [dev-dependencies]
-reqwest = { version = "0.12", default-features = false, features = ["rustls-tls"] }
+reqwest = { version = "0.12", default-features = false, features = ["rustls-tls", "json"] }


### PR DESCRIPTION
## Summary
- expose miner stats via axum with `/`, `/api/stats`, `/metrics`, and `/events`
- track hashrate, pool settings, TLS, and dev fee share counts
- integrate metrics collection into mining loop

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68c5b26a09bc83338f00b53b1f5de3ca