### PR TITLE
Add neumorphic dashboard for HTTP monitoring

### DIFF
--- a/crates/oxide-miner/static/app.js
+++ b/crates/oxide-miner/static/app.js
@@ -1,0 +1,19 @@
+async function update() {
+    try {
+        const resp = await fetch('/api/stats');
+        const data = await resp.json();
+        document.getElementById('pool').textContent = data.pool;
+        document.getElementById('status').textContent = data.connected ? 'Connected' : 'Disconnected';
+        document.getElementById('hashrate').textContent = data.hashrate.toFixed(2);
+        document.getElementById('hashes').textContent = data.hashes_total;
+        document.getElementById('accepted').textContent = data.shares.accepted;
+        document.getElementById('rejected').textContent = data.shares.rejected;
+        document.getElementById('dev_accepted').textContent = data.shares.dev_accepted;
+        document.getElementById('dev_rejected').textContent = data.shares.dev_rejected;
+    } catch (e) {
+        console.error('Failed to fetch stats', e);
+    }
+}
+
+setInterval(update, 1000);
+update();

--- a/crates/oxide-miner/static/index.html
+++ b/crates/oxide-miner/static/index.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Oxide Miner Dashboard</title>
+    <link rel="stylesheet" href="/style.css">
+</head>
+<body>
+    <div class="container">
+        <h1>Oxide Miner</h1>
+        <div class="card">
+            <div class="stat"><span>Pool:</span> <span id="pool">-</span></div>
+            <div class="stat"><span>Status:</span> <span id="status">-</span></div>
+            <div class="stat"><span>Hashrate:</span> <span id="hashrate">-</span></div>
+            <div class="stat"><span>Hashes:</span> <span id="hashes">-</span></div>
+            <div class="stat"><span>Shares:</span>
+                <div class="shares">
+                    <div>Accepted: <span id="accepted">0</span></div>
+                    <div>Rejected: <span id="rejected">0</span></div>
+                    <div>Dev Accepted: <span id="dev_accepted">0</span></div>
+                    <div>Dev Rejected: <span id="dev_rejected">0</span></div>
+                </div>
+            </div>
+        </div>
+    </div>
+    <script src="/app.js"></script>
+</body>
+</html>

--- a/crates/oxide-miner/static/style.css
+++ b/crates/oxide-miner/static/style.css
@@ -1,0 +1,35 @@
+body {
+    background: #e0e0e0;
+    font-family: Arial, sans-serif;
+    color: #333;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    height: 100vh;
+    margin: 0;
+}
+
+.container {
+    text-align: center;
+}
+
+.card {
+    background: #e0e0e0;
+    border-radius: 20px;
+    box-shadow: 9px 9px 16px #bebebe,
+                -9px -9px 16px #ffffff;
+    padding: 20px 30px;
+}
+
+.stat {
+    margin: 10px 0;
+}
+
+.stat span:first-child {
+    font-weight: bold;
+    margin-right: 5px;
+}
+
+.shares div {
+    margin: 5px 0;
+}


### PR DESCRIPTION
## Summary
- serve a styled dashboard using static HTML, CSS and vanilla JS
- expose `/app.js` and `/style.css` routes in the HTTP API
- test that the dashboard endpoint responds successfully

## Testing
- `cargo fmt --all -- --check`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68c613b293dc8333970296e69f851074