### PR TITLE
Add Neumorphic dashboard assets and HTTP serving

### DIFF
--- a/crates/oxide-miner/assets/dashboard.css
+++ b/crates/oxide-miner/assets/dashboard.css
@@ -1,0 +1,42 @@
+body {
+    font-family: Arial, sans-serif;
+    background: #e0e0e0;
+    margin: 0;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    min-height: 100vh;
+}
+
+.container {
+    max-width: 800px;
+    width: 100%;
+    padding: 20px;
+}
+
+h1 {
+    text-align: center;
+    margin-bottom: 20px;
+}
+
+.card {
+    background: #e0e0e0;
+    border-radius: 12px;
+    box-shadow: 9px 9px 16px #bebebe,
+                -9px -9px 16px #ffffff;
+    padding: 20px;
+    margin-bottom: 20px;
+}
+
+.card h2 {
+    margin-top: 0;
+}
+
+ul {
+    list-style: none;
+    padding: 0;
+}
+
+li {
+    margin: 4px 0;
+}

--- a/crates/oxide-miner/assets/dashboard.html
+++ b/crates/oxide-miner/assets/dashboard.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Oxide Miner Dashboard</title>
+    <link rel="stylesheet" href="/dashboard.css">
+</head>
+<body>
+    <div class="container">
+        <h1>Oxide Miner Dashboard</h1>
+        <div class="card">
+            <h2>Hashrate</h2>
+            <p id="hashrate">0</p>
+        </div>
+        <div class="card">
+            <h2>Total Hashes</h2>
+            <p id="hashes">0</p>
+        </div>
+        <div class="card">
+            <h2>Pool</h2>
+            <p id="pool">-</p>
+        </div>
+        <div class="card">
+            <h2>Connection</h2>
+            <p id="connected">-</p>
+        </div>
+        <div class="card">
+            <h2>Shares</h2>
+            <ul>
+                <li>Accepted: <span id="shares_accepted">0</span></li>
+                <li>Rejected: <span id="shares_rejected">0</span></li>
+                <li>Dev Accepted: <span id="shares_dev_accepted">0</span></li>
+                <li>Dev Rejected: <span id="shares_dev_rejected">0</span></li>
+            </ul>
+        </div>
+    </div>
+    <script src="/dashboard.js"></script>
+</body>
+</html>

--- a/crates/oxide-miner/assets/dashboard.js
+++ b/crates/oxide-miner/assets/dashboard.js
@@ -1,0 +1,20 @@
+async function fetchStats() {
+    try {
+        const response = await fetch('/api/stats');
+        if (!response.ok) return;
+        const data = await response.json();
+        document.getElementById('hashrate').textContent = data.hashrate.toFixed(2) + ' H/s';
+        document.getElementById('hashes').textContent = data.hashes_total;
+        document.getElementById('pool').textContent = data.pool;
+        document.getElementById('connected').textContent = data.connected ? 'Yes' : 'No';
+        document.getElementById('shares_accepted').textContent = data.shares.accepted;
+        document.getElementById('shares_rejected').textContent = data.shares.rejected;
+        document.getElementById('shares_dev_accepted').textContent = data.shares.dev_accepted;
+        document.getElementById('shares_dev_rejected').textContent = data.shares.dev_rejected;
+    } catch (err) {
+        console.error('Failed to fetch stats', err);
+    }
+}
+
+setInterval(fetchStats, 1000);
+fetchStats();

--- a/crates/oxide-miner/src/http_api.rs
+++ b/crates/oxide-miner/src/http_api.rs
@@ -12,10 +12,10 @@ use std::sync::{atomic::Ordering, Arc};
 use tokio::net::TcpListener;
 use tracing::info;
 
-const DASHBOARD_HTML: &str = r#"<!DOCTYPE html><html><body><pre id='stats'></pre><script>
-async function update(){const r=await fetch('/api/stats');const j=await r.json();document.getElementById('stats').textContent=JSON.stringify(j,null,2);}
-setInterval(update,1000);update();
-</script></body></html>"#;
+// Static assets for the lightweight dashboard.
+const DASHBOARD_HTML: &str = include_str!("../assets/dashboard.html");
+const DASHBOARD_CSS: &str = include_str!("../assets/dashboard.css");
+const DASHBOARD_JS: &str = include_str!("../assets/dashboard.js");
 
 pub async fn run_http_api(port: u16, stats: Arc<Stats>) {
     let addr = SocketAddr::from(([127, 0, 0, 1], port));
@@ -53,8 +53,12 @@ pub async fn run_http_api(port: u16, stats: Arc<Stats>) {
                             let dev_rej = s.dev_rejected.load(Ordering::Relaxed);
                             let hashes = s.hashes.load(Ordering::Relaxed);
                             let hashrate = s.hashrate();
-                            let connected = if s.pool_connected.load(Ordering::Relaxed) {1} else {0};
-                            let tls = if s.tls {1} else {0};
+                            let connected = if s.pool_connected.load(Ordering::Relaxed) {
+                                1
+                            } else {
+                                0
+                            };
+                            let tls = if s.tls { 1 } else { 0 };
                             use std::fmt::Write;
                             writeln!(body, "oxide_hashes_total {}", hashes).ok();
                             writeln!(body, "oxide_hashrate {}", hashrate).ok();
@@ -65,7 +69,10 @@ pub async fn run_http_api(port: u16, stats: Arc<Stats>) {
                             writeln!(body, "oxide_pool_connected {}", connected).ok();
                             writeln!(body, "oxide_tls_enabled {}", tls).ok();
                             let mut resp = Response::new(Full::new(Bytes::from(body)));
-                            resp.headers_mut().insert(header::CONTENT_TYPE, header::HeaderValue::from_static("text/plain"));
+                            resp.headers_mut().insert(
+                                header::CONTENT_TYPE,
+                                header::HeaderValue::from_static("text/plain"),
+                            );
                             Ok::<_, Infallible>(resp)
                         }
                         (&Method::GET, "/api/stats") => {
@@ -87,24 +94,51 @@ pub async fn run_http_api(port: u16, stats: Arc<Stats>) {
                                     "dev_accepted": dev_acc,
                                     "dev_rejected": dev_rej,
                                 }
-                            }).to_string();
+                            })
+                            .to_string();
                             let mut resp = Response::new(Full::new(Bytes::from(resp_body)));
-                            resp.headers_mut().insert(header::CONTENT_TYPE, header::HeaderValue::from_static("application/json"));
+                            resp.headers_mut().insert(
+                                header::CONTENT_TYPE,
+                                header::HeaderValue::from_static("application/json"),
+                            );
                             Ok::<_, Infallible>(resp)
                         }
                         (&Method::GET, "/") => {
-                            let mut resp = Response::new(Full::new(Bytes::from_static(DASHBOARD_HTML.as_bytes())));
-                            resp.headers_mut().insert(header::CONTENT_TYPE, header::HeaderValue::from_static("text/html"));
+                            let mut resp = Response::new(Full::new(Bytes::from_static(
+                                DASHBOARD_HTML.as_bytes(),
+                            )));
+                            resp.headers_mut().insert(
+                                header::CONTENT_TYPE,
+                                header::HeaderValue::from_static("text/html"),
+                            );
                             Ok::<_, Infallible>(resp)
                         }
-                        _ => {
-                            Ok::<_, Infallible>(
-                                Response::builder()
-                                    .status(404)
-                                    .body(Full::new(Bytes::from("not found")))
-                                    .unwrap(),
-                            )
+                        (&Method::GET, "/dashboard.css") => {
+                            let mut resp = Response::new(Full::new(Bytes::from_static(
+                                DASHBOARD_CSS.as_bytes(),
+                            )));
+                            resp.headers_mut().insert(
+                                header::CONTENT_TYPE,
+                                header::HeaderValue::from_static("text/css"),
+                            );
+                            Ok::<_, Infallible>(resp)
                         }
+                        (&Method::GET, "/dashboard.js") => {
+                            let mut resp = Response::new(Full::new(Bytes::from_static(
+                                DASHBOARD_JS.as_bytes(),
+                            )));
+                            resp.headers_mut().insert(
+                                header::CONTENT_TYPE,
+                                header::HeaderValue::from_static("application/javascript"),
+                            );
+                            Ok::<_, Infallible>(resp)
+                        }
+                        _ => Ok::<_, Infallible>(
+                            Response::builder()
+                                .status(404)
+                                .body(Full::new(Bytes::from("not found")))
+                                .unwrap(),
+                        ),
                     }
                 }
             });
@@ -121,8 +155,8 @@ mod tests {
     use super::run_http_api;
     use crate::stats::Stats;
     use reqwest::Client;
-    use std::sync::Arc;
     use std::sync::atomic::Ordering;
+    use std::sync::Arc;
     use tokio::time::{sleep, Duration};
 
     #[tokio::test]


### PR DESCRIPTION
## Summary
- Serve `/`, `/dashboard.css`, and `/dashboard.js` using embedded static assets
- Add HTML/CSS/JS dashboard with vanilla updates and neumorphic styling

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68c613b293dc8333970296e69f851074