### PR TITLE
Enable Windows large page privilege before RandomX allocations

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ hyper-util = { version = "0.1", features = ["server", "tokio"] }
 http-body-util = "0.1"
 sysinfo = "0.30"
 raw-cpuid = "11"
-windows-sys = { version = "0.52", features = ["Win32_System_Memory"] }
+windows-sys = { version = "0.52", features = ["Win32_Foundation", "Win32_Security", "Win32_Security_Authorization", "Win32_System_Memory", "Win32_System_Threading"] }
 
 [profile.release]
 lto = true

--- a/crates/oxide-core/Cargo.toml
+++ b/crates/oxide-core/Cargo.toml
@@ -27,4 +27,4 @@ sysinfo = { workspace = true }
 raw-cpuid = { workspace = true }
 
 [target.'cfg(target_os = "windows")'.dependencies]
-windows-sys = { workspace = true, features = ["Win32_System_Memory"] }
+windows-sys = { workspace = true, features = ["Win32_Foundation", "Win32_Security", "Win32_Security_Authorization", "Win32_System_Memory", "Win32_System_Threading"] }

--- a/crates/oxide-core/src/lib.rs
+++ b/crates/oxide-core/src/lib.rs
@@ -10,6 +10,7 @@ pub use config::Config;
 pub use devfee::{DevFeeScheduler, DEV_FEE_BASIS_POINTS, DEV_WALLET_ADDRESS};
 pub use stratum::{PoolJob, StratumClient};
 pub use system::{
-    autotune_snapshot, cpu_has_aes, huge_pages_enabled, recommended_thread_count, AutoTuneSnapshot,
+    autotune_snapshot, cpu_has_aes, enable_large_page_privilege, huge_pages_enabled,
+    recommended_thread_count, AutoTuneSnapshot,
 };
 pub use worker::{spawn_workers, Share, WorkItem};

--- a/crates/oxide-miner/src/miner.rs
+++ b/crates/oxide-miner/src/miner.rs
@@ -67,6 +67,11 @@ pub async fn run(args: Args) -> Result<()> {
         let snap = autotune_snapshot();
         let n_workers = args.threads.unwrap_or(snap.suggested_threads);
         let large_pages = args.huge_pages && hp_supported;
+        if large_pages {
+            if let Err(e) = oxide_core::enable_large_page_privilege() {
+                tracing::warn!(error = ?e, "failed to enable SeLockMemoryPrivilege; large pages may be unavailable");
+            }
+        }
         tracing::info!(
             "benchmark: threads={} batch_size={} large_pages={} yield={}",
             n_workers,
@@ -119,6 +124,11 @@ pub async fn run(args: Args) -> Result<()> {
 
     // If spawn call passes a 'large_pages' boolean, prefer user opt-in AND OS support
     let large_pages = cfg.huge_pages && hp_supported;
+    if large_pages {
+        if let Err(e) = oxide_core::enable_large_page_privilege() {
+            tracing::warn!(error = ?e, "failed to enable SeLockMemoryPrivilege; large pages may be unavailable");
+        }
+    }
 
     if let Some(user_t) = cfg.threads {
         tracing::info!(


### PR DESCRIPTION
## Summary
- add a Windows-specific helper that enables the SeLockMemoryPrivilege so large-page VirtualAlloc calls can succeed
- expose the helper and invoke it from the miner/benchmark paths when large pages are requested
- extend the `windows-sys` dependency features so the new privilege adjustments compile

## Testing
- cargo fmt
- cargo test


------
https://chatgpt.com/codex/tasks/task_e_68cf38f79a708333b865ba768a0be708