### PR TITLE
Support OS large/huge pages

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,12 @@ hyper-util = { version = "0.1", features = ["server", "tokio"] }
 http-body-util = "0.1"
 sysinfo = "0.30"
 raw-cpuid = "11"
-windows-sys = { version = "0.52", features = ["Win32_System_Memory"] }
+windows-sys = { version = "0.52", features = [
+    "Win32_Foundation",
+    "Win32_Security",
+    "Win32_System_Memory",
+    "Win32_System_Threading",
+] }
 
 [profile.release]
 lto = true

--- a/crates/oxide-core/Cargo.toml
+++ b/crates/oxide-core/Cargo.toml
@@ -27,4 +27,9 @@ sysinfo = { workspace = true }
 raw-cpuid = { workspace = true }
 
 [target.'cfg(target_os = "windows")'.dependencies]
-windows-sys = { workspace = true, features = ["Win32_System_Memory"] }
+windows-sys = { workspace = true, features = [
+    "Win32_Foundation",
+    "Win32_Security",
+    "Win32_System_Memory",
+    "Win32_System_Threading",
+] }

--- a/crates/oxide-miner/Cargo.toml
+++ b/crates/oxide-miner/Cargo.toml
@@ -5,8 +5,12 @@ name = "oxide-miner"
 version = "0.1.0"
 edition = "2021"
 
+[features]
+default = ["randomx"]
+randomx = ["oxide-core/randomx"]
+
 [dependencies]
-oxide-core = { path = "../oxide-core", features = ["randomx"] }
+oxide-core = { path = "../oxide-core", default-features = false }
 anyhow = { workspace = true }
 clap = { workspace = true }
 tokio = { workspace = true }


### PR DESCRIPTION
## Summary
- add cross-platform large page preparation logic and enable SeLockMemoryPrivilege on Windows before requesting RandomX large pages
- update mining and benchmark flows to attempt large/huge page activation with graceful fallbacks when privileges are missing
- expose the required windows-sys APIs and crate features so the new privilege handling compiles cleanly on all targets

## Testing
- cargo test

------
https://chatgpt.com/codex/tasks/task_e_68cf47c30be08333a331d06d51403c38