### PR TITLE
Support large page privileges on Windows

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,12 @@ hyper-util = { version = "0.1", features = ["server", "tokio"] }
 http-body-util = "0.1"
 sysinfo = "0.30"
 raw-cpuid = "11"
-windows-sys = { version = "0.52", features = ["Win32_System_Memory"] }
+windows-sys = { version = "0.52", features = [
+    "Win32_Foundation",
+    "Win32_Security",
+    "Win32_System_Memory",
+    "Win32_System_Threading",
+] }
 
 [profile.release]
 lto = true


### PR DESCRIPTION
## Summary
- expand the `windows-sys` dependency so we can call security and threading APIs on Windows
- detect Windows large page support by enabling `SeLockMemoryPrivilege` and caching the result
- keep the existing Linux huge page check while routing platform checks through helper functions

## Testing
- `cargo fmt -- crates/oxide-core/src/system.rs`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68cf47c30be08333a331d06d51403c38