### PR TITLE
Support OS huge page privileges

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,13 @@ hyper-util = { version = "0.1", features = ["server", "tokio"] }
 http-body-util = "0.1"
 sysinfo = "0.30"
 raw-cpuid = "11"
-windows-sys = { version = "0.52", features = ["Win32_System_Memory"] }
+windows-sys = { version = "0.52", features = [
+    "Win32_Foundation",
+    "Win32_Security",
+    "Win32_System_Memory",
+    "Win32_System_SystemServices",
+    "Win32_System_Threading",
+] }
 
 [profile.release]
 lto = true

--- a/crates/oxide-core/Cargo.toml
+++ b/crates/oxide-core/Cargo.toml
@@ -27,4 +27,4 @@ sysinfo = { workspace = true }
 raw-cpuid = { workspace = true }
 
 [target.'cfg(target_os = "windows")'.dependencies]
-windows-sys = { workspace = true, features = ["Win32_System_Memory"] }
+windows-sys = { workspace = true }

--- a/crates/oxide-core/src/worker.rs
+++ b/crates/oxide-core/src/worker.rs
@@ -1,5 +1,8 @@
 use anyhow::Result;
-use std::sync::{Arc, atomic::{AtomicU64, Ordering}};
+use std::sync::{
+    atomic::{AtomicU64, Ordering},
+    Arc,
+};
 use std::time::{SystemTime, UNIX_EPOCH};
 use tokio::sync::{broadcast, mpsc};
 
@@ -114,7 +117,33 @@ mod engine {
     static LARGE_PAGES: AtomicBool = AtomicBool::new(false);
 
     pub fn set_large_pages(enable: bool) {
-        LARGE_PAGES.store(enable, Ordering::Relaxed);
+        let effective = if !enable {
+            false
+        } else {
+            #[cfg(target_os = "windows")]
+            {
+                match system::enable_lock_memory_privilege() {
+                    Ok(()) => true,
+                    Err(err) => {
+                        tracing::warn!(
+                            error = ?err,
+                            "failed to enable SeLockMemoryPrivilege; disabling large pages"
+                        );
+                        false
+                    }
+                }
+            }
+            #[cfg(target_os = "linux")]
+            {
+                true
+            }
+            #[cfg(not(any(target_os = "linux", target_os = "windows")))]
+            {
+                false
+            }
+        };
+
+        LARGE_PAGES.store(effective, Ordering::Relaxed);
     }
 
     fn default_flags() -> RandomXFlag {
@@ -442,15 +471,24 @@ fn meets_target(hash: &[u8; 32], job: &PoolJob) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::{atomic::AtomicU64, Arc};
     use tokio::sync::{broadcast, mpsc};
-    use std::sync::{Arc, atomic::AtomicU64};
 
     #[tokio::test]
     async fn spawns_correct_number_of_workers() {
         let (jobs_tx, _jobs_rx) = broadcast::channel(1);
         let (shares_tx, _shares_rx) = mpsc::unbounded_channel();
         let hash_counter = Arc::new(AtomicU64::new(0));
-        let handles = spawn_workers(3, jobs_tx, shares_tx, false, false, 10_000, true, hash_counter);
+        let handles = spawn_workers(
+            3,
+            jobs_tx,
+            shares_tx,
+            false,
+            false,
+            10_000,
+            true,
+            hash_counter,
+        );
         assert_eq!(handles.len(), 3);
         for h in handles {
             h.abort();


### PR DESCRIPTION
## Summary
- enable SeLockMemoryPrivilege at runtime when large pages are requested on Windows
- detect Windows large-page availability by checking both GetLargePageMinimum and SeLockMemoryPrivilege
- expose the additional Windows APIs needed through the workspace windows-sys dependency

## Testing
- cargo test

------
https://chatgpt.com/codex/tasks/task_e_68cf47c30be08333a331d06d51403c38