### PR TITLE
Enable platform-specific large page privileges

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ hyper-util = { version = "0.1", features = ["server", "tokio"] }
 http-body-util = "0.1"
 sysinfo = "0.30"
 raw-cpuid = "11"
-windows-sys = { version = "0.52", features = ["Win32_System_Memory"] }
+windows-sys = { version = "0.52", features = ["Win32_Foundation", "Win32_Security", "Win32_System_Memory", "Win32_System_Threading"] }
 
 [profile.release]
 lto = true

--- a/crates/oxide-core/src/worker.rs
+++ b/crates/oxide-core/src/worker.rs
@@ -1,5 +1,8 @@
 use anyhow::Result;
-use std::sync::{Arc, atomic::{AtomicU64, Ordering}};
+use std::sync::{
+    atomic::{AtomicU64, Ordering},
+    Arc,
+};
 use std::time::{SystemTime, UNIX_EPOCH};
 use tokio::sync::{broadcast, mpsc};
 
@@ -114,7 +117,17 @@ mod engine {
     static LARGE_PAGES: AtomicBool = AtomicBool::new(false);
 
     pub fn set_large_pages(enable: bool) {
-        LARGE_PAGES.store(enable, Ordering::Relaxed);
+        let effective = if enable {
+            system::enable_large_pages_privilege()
+        } else {
+            false
+        };
+        if enable && !effective {
+            tracing::warn!(
+                "large pages were requested but the required privilege could not be enabled; continuing without them"
+            );
+        }
+        LARGE_PAGES.store(effective, Ordering::Relaxed);
     }
 
     fn default_flags() -> RandomXFlag {
@@ -442,15 +455,24 @@ fn meets_target(hash: &[u8; 32], job: &PoolJob) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::{atomic::AtomicU64, Arc};
     use tokio::sync::{broadcast, mpsc};
-    use std::sync::{Arc, atomic::AtomicU64};
 
     #[tokio::test]
     async fn spawns_correct_number_of_workers() {
         let (jobs_tx, _jobs_rx) = broadcast::channel(1);
         let (shares_tx, _shares_rx) = mpsc::unbounded_channel();
         let hash_counter = Arc::new(AtomicU64::new(0));
-        let handles = spawn_workers(3, jobs_tx, shares_tx, false, false, 10_000, true, hash_counter);
+        let handles = spawn_workers(
+            3,
+            jobs_tx,
+            shares_tx,
+            false,
+            false,
+            10_000,
+            true,
+            hash_counter,
+        );
         assert_eq!(handles.len(), 3);
         for h in handles {
             h.abort();


### PR DESCRIPTION
## Summary
- enable SeLockMemoryPrivilege for the miner process when large pages are requested on Windows
- disable RandomX large page flag when the privilege cannot be enabled and warn the operator
- add the required Windows security/threading APIs for privilege management

## Testing
- cargo test

------
https://chatgpt.com/codex/tasks/task_e_68cf47c30be08333a331d06d51403c38