### PR TITLE
Enable cross-platform large page handling

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,12 @@ hyper-util = { version = "0.1", features = ["server", "tokio"] }
 http-body-util = "0.1"
 sysinfo = "0.30"
 raw-cpuid = "11"
-windows-sys = { version = "0.52", features = ["Win32_System_Memory"] }
+windows-sys = { version = "0.52", features = [
+    "Win32_Foundation",
+    "Win32_Security",
+    "Win32_System_Memory",
+    "Win32_System_Threading",
+] }
 
 [profile.release]
 lto = true

--- a/crates/oxide-core/Cargo.toml
+++ b/crates/oxide-core/Cargo.toml
@@ -27,4 +27,12 @@ sysinfo = { workspace = true }
 raw-cpuid = { workspace = true }
 
 [target.'cfg(target_os = "windows")'.dependencies]
-windows-sys = { workspace = true, features = ["Win32_System_Memory"] }
+windows-sys = { workspace = true, features = [
+    "Win32_Foundation",
+    "Win32_Security",
+    "Win32_System_Memory",
+    "Win32_System_Threading",
+] }
+
+[target.'cfg(target_os = "linux")'.dependencies]
+libc = "0.2"

--- a/crates/oxide-core/src/benchmark.rs
+++ b/crates/oxide-core/src/benchmark.rs
@@ -19,7 +19,19 @@ pub async fn run_benchmark(
     batch_size: usize,
     yield_between_batches: bool,
 ) -> Result<f64> {
-    set_large_pages(large_pages);
+    let use_large_pages = if large_pages {
+        if crate::system::huge_pages_enabled() {
+            true
+        } else {
+            tracing::warn!(
+                "huge pages requested for benchmark but unavailable; running without them"
+            );
+            false
+        }
+    } else {
+        false
+    };
+    set_large_pages(use_large_pages);
     let duration = Duration::from_secs(seconds);
     let threads_u32 = threads as u32;
 

--- a/crates/oxide-core/src/stratum.rs
+++ b/crates/oxide-core/src/stratum.rs
@@ -126,7 +126,8 @@ impl StratumClient {
                             client.session_id = Some(id.to_string());
                         }
                         if let Some(job_val) = obj.get("job") {
-                            if let Ok(mut job) = serde_json::from_value::<PoolJob>(job_val.clone()) {
+                            if let Ok(mut job) = serde_json::from_value::<PoolJob>(job_val.clone())
+                            {
                                 job.cache_target();
                                 tracing::info!("initial job (in login result)");
                                 break Some(job);
@@ -240,7 +241,11 @@ impl StratumClient {
     async fn read_line(&mut self) -> Result<String> {
         let mut buf = String::new();
         let n = self.reader.read_line(&mut buf).await?;
-        if n == 0 { Ok(String::new()) } else { Ok(buf) }
+        if n == 0 {
+            Ok(String::new())
+        } else {
+            Ok(buf)
+        }
     }
 }
 
@@ -251,11 +256,17 @@ mod tests {
 
     #[test]
     fn request_ids_increment() {
-        let reader: BufReader<Box<dyn io::AsyncRead + Unpin + Send>> =
-            BufReader::with_capacity(4096, Box::new(io::empty()) as Box<dyn io::AsyncRead + Unpin + Send>);
-        let writer: Box<dyn io::AsyncWrite + Unpin + Send> =
-            Box::new(io::sink());
-        let mut client = StratumClient { reader, writer, session_id: None, next_req_id: 1 };
+        let reader: BufReader<Box<dyn io::AsyncRead + Unpin + Send>> = BufReader::with_capacity(
+            4096,
+            Box::new(io::empty()) as Box<dyn io::AsyncRead + Unpin + Send>,
+        );
+        let writer: Box<dyn io::AsyncWrite + Unpin + Send> = Box::new(io::sink());
+        let mut client = StratumClient {
+            reader,
+            writer,
+            session_id: None,
+            next_req_id: 1,
+        };
         assert_eq!(client.take_req_id(), 1);
         assert_eq!(client.take_req_id(), 2);
     }
@@ -263,10 +274,17 @@ mod tests {
     #[tokio::test]
     async fn send_line_appends_newline() {
         let (write_half, mut read_half) = io::duplex(64);
-        let reader: BufReader<Box<dyn io::AsyncRead + Unpin + Send>> =
-            BufReader::with_capacity(4096, Box::new(io::empty()) as Box<dyn io::AsyncRead + Unpin + Send>);
+        let reader: BufReader<Box<dyn io::AsyncRead + Unpin + Send>> = BufReader::with_capacity(
+            4096,
+            Box::new(io::empty()) as Box<dyn io::AsyncRead + Unpin + Send>,
+        );
         let writer: Box<dyn io::AsyncWrite + Unpin + Send> = Box::new(write_half);
-        let mut client = StratumClient { reader, writer, session_id: None, next_req_id: 1 };
+        let mut client = StratumClient {
+            reader,
+            writer,
+            session_id: None,
+            next_req_id: 1,
+        };
         client.send_line("ping".into()).await.unwrap();
         let mut buf = [0u8; 5];
         read_half.read_exact(&mut buf).await.unwrap();
@@ -279,10 +297,17 @@ mod tests {
         tokio::spawn(async move {
             write_side.write_all(b"garbage\n{\"a\":1}\n").await.unwrap();
         });
-        let reader: BufReader<Box<dyn io::AsyncRead + Unpin + Send>> =
-            BufReader::with_capacity(4096, Box::new(read_side) as Box<dyn io::AsyncRead + Unpin + Send>);
+        let reader: BufReader<Box<dyn io::AsyncRead + Unpin + Send>> = BufReader::with_capacity(
+            4096,
+            Box::new(read_side) as Box<dyn io::AsyncRead + Unpin + Send>,
+        );
         let writer: Box<dyn io::AsyncWrite + Unpin + Send> = Box::new(io::sink());
-        let mut client = StratumClient { reader, writer, session_id: None, next_req_id: 1 };
+        let mut client = StratumClient {
+            reader,
+            writer,
+            session_id: None,
+            next_req_id: 1,
+        };
         let v = client.read_json().await.unwrap();
         assert_eq!(v.get("a").and_then(|x| x.as_u64()), Some(1));
     }

--- a/crates/oxide-core/src/system.rs
+++ b/crates/oxide-core/src/system.rs
@@ -7,41 +7,224 @@
 
 use sysinfo::System;
 
+#[cfg(target_os = "windows")]
+use once_cell::sync::OnceCell;
+
+/// Size of the RandomX "fast" dataset (~2 GiB).
+pub const RANDOMX_DATASET_BYTES: u64 = 2_u64 * 1024 * 1024 * 1024;
+/// Approximate scratchpad memory used per mining thread (~2 MiB).
+pub const RANDOMX_SCRATCH_PER_THREAD_BYTES: u64 = 2_u64 * 1024 * 1024;
+
+/// Summary of the system's large/huge page capabilities.
+#[derive(Debug, Clone)]
+pub struct HugePageInfo {
+    /// Operating system large/huge page size in bytes.
+    pub page_size: u64,
+    /// Total amount of memory backed by large/huge pages when known.
+    pub total_bytes: Option<u64>,
+    /// Currently free large/huge page memory when known.
+    pub free_bytes: Option<u64>,
+}
+
+/// Query operating system support for large/huge pages.
+pub fn huge_page_info() -> Option<HugePageInfo> {
+    detect_huge_page_info()
+}
+
 /// Check if operating system has huge pages / large pages available.
 /// On Linux this inspects `/proc/meminfo`'s `HugePages_Total` value.
 /// On Windows it queries `GetLargePageMinimum`.
 pub fn huge_pages_enabled() -> bool {
-    #[cfg(target_os = "linux")]
-    {
-        if let Ok(meminfo) = std::fs::read_to_string("/proc/meminfo") {
-            return parse_hugepages_total(&meminfo);
-        }
-        false
-    }
-    #[cfg(target_os = "windows")]
-    {
-        // windows-sys with feature Win32_System_Memory
-        use windows_sys::Win32::System::Memory::GetLargePageMinimum;
-        unsafe { GetLargePageMinimum() > 0 }
-    }
-    #[cfg(not(any(target_os = "linux", target_os = "windows")))]
-    {
-        false
+    match huge_page_info() {
+        Some(info) => match info.free_bytes {
+            // When the OS exposes a free counter ensure the RandomX dataset (~2 GiB) fits.
+            Some(bytes) => bytes >= RANDOMX_DATASET_BYTES,
+            // On Windows we verify availability by probing an allocation, but do not know
+            // the remaining capacity. Assume availability if the probe succeeded.
+            None => true,
+        },
+        None => false,
     }
 }
 
 #[cfg(target_os = "linux")]
-fn parse_hugepages_total(meminfo: &str) -> bool {
+fn detect_huge_page_info() -> Option<HugePageInfo> {
+    let meminfo = std::fs::read_to_string("/proc/meminfo").ok()?;
+    let total_pages = parse_meminfo_value(&meminfo, "HugePages_Total")?;
+    if total_pages == 0 {
+        return None;
+    }
+    let free_pages = parse_meminfo_value(&meminfo, "HugePages_Free").unwrap_or(0);
+    if free_pages == 0 {
+        return None;
+    }
+    let page_kib = parse_meminfo_value(&meminfo, "Hugepagesize")?;
+    if page_kib == 0 {
+        return None;
+    }
+
+    let page_size = page_kib * 1024;
+
+    // Ensure we have sufficient privilege by probing an anonymous huge page mapping.
+    if !try_linux_huge_page_alloc(page_size as usize) {
+        return None;
+    }
+
+    Some(HugePageInfo {
+        page_size: page_size as u64,
+        total_bytes: Some(total_pages as u64 * page_size as u64),
+        free_bytes: Some(free_pages as u64 * page_size as u64),
+    })
+}
+
+#[cfg(target_os = "linux")]
+fn parse_meminfo_value(meminfo: &str, key: &str) -> Option<u64> {
     for line in meminfo.lines() {
-        if let Some(rest) = line.strip_prefix("HugePages_Total:") {
-            if let Some(total) = rest.trim().split_whitespace().next() {
-                if let Ok(v) = total.parse::<u64>() {
-                    return v > 0;
-                }
+        if let Some(rest) = line.strip_prefix(key) {
+            if let Some(value) = rest
+                .split_whitespace()
+                .find_map(|tok| tok.parse::<u64>().ok())
+            {
+                return Some(value);
             }
         }
     }
-    false
+    None
+}
+
+#[cfg(target_os = "linux")]
+fn try_linux_huge_page_alloc(size: usize) -> bool {
+    use libc::{
+        mmap, munmap, MAP_ANONYMOUS, MAP_FAILED, MAP_HUGETLB, MAP_PRIVATE, PROT_READ, PROT_WRITE,
+    };
+
+    unsafe {
+        let ptr = mmap(
+            std::ptr::null_mut(),
+            size,
+            PROT_READ | PROT_WRITE,
+            MAP_PRIVATE | MAP_ANONYMOUS | MAP_HUGETLB,
+            -1,
+            0,
+        );
+        if ptr == MAP_FAILED {
+            return false;
+        }
+        if munmap(ptr, size) != 0 {
+            tracing::warn!(
+                "failed to munmap test huge page mapping; continuing without huge pages"
+            );
+            return false;
+        }
+    }
+    true
+}
+
+#[cfg(target_os = "windows")]
+fn detect_huge_page_info() -> Option<HugePageInfo> {
+    use windows_sys::Win32::System::Memory::{
+        GetLargePageMinimum, VirtualAlloc, VirtualFree, MEM_COMMIT, MEM_LARGE_PAGES, MEM_RELEASE,
+        MEM_RESERVE, PAGE_READWRITE,
+    };
+
+    let size = unsafe { GetLargePageMinimum() };
+    if size == 0 {
+        return None;
+    }
+
+    if !enable_lock_memory_privilege() {
+        return None;
+    }
+
+    let ptr = unsafe {
+        VirtualAlloc(
+            std::ptr::null_mut(),
+            size as usize,
+            MEM_RESERVE | MEM_COMMIT | MEM_LARGE_PAGES,
+            PAGE_READWRITE,
+        )
+    };
+    if ptr.is_null() {
+        return None;
+    }
+
+    unsafe {
+        VirtualFree(ptr, 0, MEM_RELEASE);
+    }
+
+    Some(HugePageInfo {
+        page_size: size as u64,
+        total_bytes: None,
+        free_bytes: None,
+    })
+}
+
+#[cfg(target_os = "windows")]
+fn enable_lock_memory_privilege() -> bool {
+    static RESULT: OnceCell<bool> = OnceCell::new();
+    *RESULT.get_or_init(|| unsafe { adjust_lock_memory_privilege() })
+}
+
+#[cfg(target_os = "windows")]
+unsafe fn adjust_lock_memory_privilege() -> bool {
+    use std::mem::size_of;
+
+    use windows_sys::Win32::Foundation::{CloseHandle, GetLastError, ERROR_NOT_ALL_ASSIGNED};
+    use windows_sys::Win32::Security::{
+        AdjustTokenPrivileges, LookupPrivilegeValueW, OpenProcessToken, LUID, LUID_AND_ATTRIBUTES,
+        SE_PRIVILEGE_ENABLED, TOKEN_ADJUST_PRIVILEGES, TOKEN_PRIVILEGES, TOKEN_QUERY,
+    };
+    use windows_sys::Win32::System::Threading::GetCurrentProcess;
+
+    let mut token: isize = 0;
+    if OpenProcessToken(
+        GetCurrentProcess(),
+        TOKEN_ADJUST_PRIVILEGES | TOKEN_QUERY,
+        &mut token,
+    ) == 0
+    {
+        return false;
+    }
+
+    let name: Vec<u16> = "SeLockMemoryPrivilege\0".encode_utf16().collect();
+    let mut luid = LUID {
+        LowPart: 0,
+        HighPart: 0,
+    };
+    if LookupPrivilegeValueW(std::ptr::null(), name.as_ptr(), &mut luid) == 0 {
+        CloseHandle(token);
+        return false;
+    }
+
+    let mut privileges = TOKEN_PRIVILEGES {
+        PrivilegeCount: 1,
+        Privileges: [LUID_AND_ATTRIBUTES {
+            Luid: luid,
+            Attributes: SE_PRIVILEGE_ENABLED,
+        }],
+    };
+
+    if AdjustTokenPrivileges(
+        token,
+        0,
+        &mut privileges,
+        size_of::<TOKEN_PRIVILEGES>() as u32,
+        std::ptr::null_mut(),
+        std::ptr::null_mut(),
+    ) == 0
+    {
+        CloseHandle(token);
+        return false;
+    }
+
+    let assigned = GetLastError();
+    CloseHandle(token);
+    assigned != ERROR_NOT_ALL_ASSIGNED
+}
+
+#[cfg(not(any(target_os = "linux", target_os = "windows")))]
+fn detect_huge_page_info() -> Option<HugePageInfo> {
+    None
 }
 
 /// Determine whether the current CPU supports AES instructions (x86/x86_64).
@@ -66,10 +249,10 @@ fn l3_cache_bytes() -> Option<usize> {
             if cache.level() == 3 && matches!(cache.cache_type(), raw_cpuid::CacheType::Unified) {
                 // CPUID leaf 0x4 size formula:
                 // size = associativity * partitions * line_size * sets
-                let ways  = cache.associativity() as usize;
+                let ways = cache.associativity() as usize;
                 let parts = cache.physical_line_partitions() as usize;
-                let line  = cache.coherency_line_size() as usize;
-                let sets  = cache.sets() as usize;
+                let line = cache.coherency_line_size() as usize;
+                let sets = cache.sets() as usize;
                 return Some(ways * parts * line * sets);
             }
         }
@@ -107,14 +290,18 @@ pub fn autotune_snapshot() -> AutoTuneSnapshot {
     let avail_bytes = sys.available_memory();
 
     // RandomX "fast" dataset and per-thread scratchpad estimates
-    let dataset = 2_u64 * 1024 * 1024 * 1024; // ~2 GiB
-    let scratch = 2_u64 * 1024 * 1024;        // ~2 MiB per thread
+    let dataset = RANDOMX_DATASET_BYTES;
+    let scratch = RANDOMX_SCRATCH_PER_THREAD_BYTES;
 
     let mut threads = physical;
 
     // L3 clamp (~2 MiB per thread)
     if let Some(l3b) = l3 {
-        let l3_per_thread = if l3b > 64 * 1024 * 1024 { 4 * 1024 * 1024 } else { 2 * 1024 * 1024 };
+        let l3_per_thread = if l3b > 64 * 1024 * 1024 {
+            4 * 1024 * 1024
+        } else {
+            2 * 1024 * 1024
+        };
         let cache_threads = (l3b / l3_per_thread).max(1);
         threads = threads.min(cache_threads);
     }
@@ -148,13 +335,16 @@ mod tests {
 
     #[cfg(target_os = "linux")]
     #[test]
-    fn parses_hugepages_total() {
-        let enabled = "HugePages_Total:       5\nOther: 0";
-        assert!(parse_hugepages_total(enabled));
-        let disabled = "HugePages_Total:       0\nOther: 0";
-        assert!(!parse_hugepages_total(disabled));
-        let missing = "SomethingElse: 1";
-        assert!(!parse_hugepages_total(missing));
+    fn parses_hugepages_entries() {
+        let enabled =
+            "HugePages_Total:       5\nHugePages_Free:       3\nHugepagesize:       2048 kB";
+        assert_eq!(parse_meminfo_value(enabled, "HugePages_Total"), Some(5));
+        assert_eq!(parse_meminfo_value(enabled, "HugePages_Free"), Some(3));
+        assert_eq!(parse_meminfo_value(enabled, "Hugepagesize"), Some(2048));
+        assert_eq!(
+            parse_meminfo_value("SomethingElse: 1", "HugePages_Total"),
+            None
+        );
     }
 
     #[test]

--- a/crates/oxide-core/src/worker.rs
+++ b/crates/oxide-core/src/worker.rs
@@ -1,5 +1,8 @@
 use anyhow::Result;
-use std::sync::{Arc, atomic::{AtomicU64, Ordering}};
+use std::sync::{
+    atomic::{AtomicU64, Ordering},
+    Arc,
+};
 use std::time::{SystemTime, UNIX_EPOCH};
 use tokio::sync::{broadcast, mpsc};
 
@@ -114,7 +117,33 @@ mod engine {
     static LARGE_PAGES: AtomicBool = AtomicBool::new(false);
 
     pub fn set_large_pages(enable: bool) {
-        LARGE_PAGES.store(enable, Ordering::Relaxed);
+        if !enable {
+            LARGE_PAGES.store(false, Ordering::Relaxed);
+            return;
+        }
+
+        match system::huge_page_info() {
+            Some(info) => {
+                if let Some(free) = info.free_bytes {
+                    if free < system::RANDOMX_DATASET_BYTES {
+                        tracing::warn!(
+                            available_bytes = free,
+                            required_bytes = system::RANDOMX_DATASET_BYTES,
+                            "huge pages requested but insufficient free huge pages reserved; falling back",
+                        );
+                        LARGE_PAGES.store(false, Ordering::Relaxed);
+                        return;
+                    }
+                }
+                LARGE_PAGES.store(true, Ordering::Relaxed);
+            }
+            None => {
+                tracing::warn!(
+                    "huge pages requested but unavailable; falling back to standard memory"
+                );
+                LARGE_PAGES.store(false, Ordering::Relaxed);
+            }
+        }
     }
 
     fn default_flags() -> RandomXFlag {
@@ -442,15 +471,24 @@ fn meets_target(hash: &[u8; 32], job: &PoolJob) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::{atomic::AtomicU64, Arc};
     use tokio::sync::{broadcast, mpsc};
-    use std::sync::{Arc, atomic::AtomicU64};
 
     #[tokio::test]
     async fn spawns_correct_number_of_workers() {
         let (jobs_tx, _jobs_rx) = broadcast::channel(1);
         let (shares_tx, _shares_rx) = mpsc::unbounded_channel();
         let hash_counter = Arc::new(AtomicU64::new(0));
-        let handles = spawn_workers(3, jobs_tx, shares_tx, false, false, 10_000, true, hash_counter);
+        let handles = spawn_workers(
+            3,
+            jobs_tx,
+            shares_tx,
+            false,
+            false,
+            10_000,
+            true,
+            hash_counter,
+        );
         assert_eq!(handles.len(), 3);
         for h in handles {
             h.abort();

--- a/crates/oxide-miner/src/main.rs
+++ b/crates/oxide-miner/src/main.rs
@@ -1,8 +1,8 @@
 mod args;
 mod http_api;
 mod miner;
-mod util;
 mod stats;
+mod util;
 
 use anyhow::Result;
 use args::Args;

--- a/crates/oxide-miner/src/miner.rs
+++ b/crates/oxide-miner/src/miner.rs
@@ -148,7 +148,7 @@ pub async fn run(args: Args) -> Result<()> {
     // MPSC: shares <- workers
     let (shares_tx, mut shares_rx) = tokio::sync::mpsc::unbounded_channel::<Share>();
 
-    if !huge_pages_enabled() {
+    if !hp_supported {
         tracing::warn!("huge pages are not enabled; mining performance may be reduced");
     }
 


### PR DESCRIPTION
## Summary
- add operating system specific huge page detection with dataset constants and privilege checks
- guard worker and benchmark RandomX allocations with the detection results and log fallbacks
- pull in the Windows privilege and Linux libc dependencies required for probing huge pages

## Testing
- cargo test

------
https://chatgpt.com/codex/tasks/task_e_68cf6917efe48333900417bad1bc0f2e