### PR TITLE
Enable cross-platform huge page support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,13 @@ hyper-util = { version = "0.1", features = ["server", "tokio"] }
 http-body-util = "0.1"
 sysinfo = "0.30"
 raw-cpuid = "11"
-windows-sys = { version = "0.52", features = ["Win32_System_Memory"] }
+windows-sys = { version = "0.52", features = [
+    "Win32_Foundation",
+    "Win32_Security",
+    "Win32_System_Memory",
+    "Win32_System_SystemServices",
+    "Win32_System_Threading",
+] }
 
 [profile.release]
 lto = true

--- a/crates/oxide-core/Cargo.toml
+++ b/crates/oxide-core/Cargo.toml
@@ -27,4 +27,10 @@ sysinfo = { workspace = true }
 raw-cpuid = { workspace = true }
 
 [target.'cfg(target_os = "windows")'.dependencies]
-windows-sys = { workspace = true, features = ["Win32_System_Memory"] }
+windows-sys = { workspace = true, features = [
+    "Win32_Foundation",
+    "Win32_Security",
+    "Win32_System_Memory",
+    "Win32_System_SystemServices",
+    "Win32_System_Threading",
+] }

--- a/crates/oxide-core/src/benchmark.rs
+++ b/crates/oxide-core/src/benchmark.rs
@@ -19,7 +19,7 @@ pub async fn run_benchmark(
     batch_size: usize,
     yield_between_batches: bool,
 ) -> Result<f64> {
-    set_large_pages(large_pages);
+    let _ = set_large_pages(large_pages);
     let duration = Duration::from_secs(seconds);
     let threads_u32 = threads as u32;
 

--- a/crates/oxide-core/src/lib.rs
+++ b/crates/oxide-core/src/lib.rs
@@ -10,6 +10,7 @@ pub use config::Config;
 pub use devfee::{DevFeeScheduler, DEV_FEE_BASIS_POINTS, DEV_WALLET_ADDRESS};
 pub use stratum::{PoolJob, StratumClient};
 pub use system::{
-    autotune_snapshot, cpu_has_aes, huge_pages_enabled, recommended_thread_count, AutoTuneSnapshot,
+    autotune_snapshot, cpu_has_aes, huge_page_status, huge_pages_enabled, recommended_thread_count,
+    AutoTuneSnapshot, HugePageStatus,
 };
 pub use worker::{spawn_workers, Share, WorkItem};

--- a/crates/oxide-core/src/stratum.rs
+++ b/crates/oxide-core/src/stratum.rs
@@ -126,7 +126,8 @@ impl StratumClient {
                             client.session_id = Some(id.to_string());
                         }
                         if let Some(job_val) = obj.get("job") {
-                            if let Ok(mut job) = serde_json::from_value::<PoolJob>(job_val.clone()) {
+                            if let Ok(mut job) = serde_json::from_value::<PoolJob>(job_val.clone())
+                            {
                                 job.cache_target();
                                 tracing::info!("initial job (in login result)");
                                 break Some(job);
@@ -240,7 +241,11 @@ impl StratumClient {
     async fn read_line(&mut self) -> Result<String> {
         let mut buf = String::new();
         let n = self.reader.read_line(&mut buf).await?;
-        if n == 0 { Ok(String::new()) } else { Ok(buf) }
+        if n == 0 {
+            Ok(String::new())
+        } else {
+            Ok(buf)
+        }
     }
 }
 
@@ -251,11 +256,17 @@ mod tests {
 
     #[test]
     fn request_ids_increment() {
-        let reader: BufReader<Box<dyn io::AsyncRead + Unpin + Send>> =
-            BufReader::with_capacity(4096, Box::new(io::empty()) as Box<dyn io::AsyncRead + Unpin + Send>);
-        let writer: Box<dyn io::AsyncWrite + Unpin + Send> =
-            Box::new(io::sink());
-        let mut client = StratumClient { reader, writer, session_id: None, next_req_id: 1 };
+        let reader: BufReader<Box<dyn io::AsyncRead + Unpin + Send>> = BufReader::with_capacity(
+            4096,
+            Box::new(io::empty()) as Box<dyn io::AsyncRead + Unpin + Send>,
+        );
+        let writer: Box<dyn io::AsyncWrite + Unpin + Send> = Box::new(io::sink());
+        let mut client = StratumClient {
+            reader,
+            writer,
+            session_id: None,
+            next_req_id: 1,
+        };
         assert_eq!(client.take_req_id(), 1);
         assert_eq!(client.take_req_id(), 2);
     }
@@ -263,10 +274,17 @@ mod tests {
     #[tokio::test]
     async fn send_line_appends_newline() {
         let (write_half, mut read_half) = io::duplex(64);
-        let reader: BufReader<Box<dyn io::AsyncRead + Unpin + Send>> =
-            BufReader::with_capacity(4096, Box::new(io::empty()) as Box<dyn io::AsyncRead + Unpin + Send>);
+        let reader: BufReader<Box<dyn io::AsyncRead + Unpin + Send>> = BufReader::with_capacity(
+            4096,
+            Box::new(io::empty()) as Box<dyn io::AsyncRead + Unpin + Send>,
+        );
         let writer: Box<dyn io::AsyncWrite + Unpin + Send> = Box::new(write_half);
-        let mut client = StratumClient { reader, writer, session_id: None, next_req_id: 1 };
+        let mut client = StratumClient {
+            reader,
+            writer,
+            session_id: None,
+            next_req_id: 1,
+        };
         client.send_line("ping".into()).await.unwrap();
         let mut buf = [0u8; 5];
         read_half.read_exact(&mut buf).await.unwrap();
@@ -279,10 +297,17 @@ mod tests {
         tokio::spawn(async move {
             write_side.write_all(b"garbage\n{\"a\":1}\n").await.unwrap();
         });
-        let reader: BufReader<Box<dyn io::AsyncRead + Unpin + Send>> =
-            BufReader::with_capacity(4096, Box::new(read_side) as Box<dyn io::AsyncRead + Unpin + Send>);
+        let reader: BufReader<Box<dyn io::AsyncRead + Unpin + Send>> = BufReader::with_capacity(
+            4096,
+            Box::new(read_side) as Box<dyn io::AsyncRead + Unpin + Send>,
+        );
         let writer: Box<dyn io::AsyncWrite + Unpin + Send> = Box::new(io::sink());
-        let mut client = StratumClient { reader, writer, session_id: None, next_req_id: 1 };
+        let mut client = StratumClient {
+            reader,
+            writer,
+            session_id: None,
+            next_req_id: 1,
+        };
         let v = client.read_json().await.unwrap();
         assert_eq!(v.get("a").and_then(|x| x.as_u64()), Some(1));
     }

--- a/crates/oxide-core/src/system.rs
+++ b/crates/oxide-core/src/system.rs
@@ -7,41 +7,280 @@
 
 use sysinfo::System;
 
-/// Check if operating system has huge pages / large pages available.
-/// On Linux this inspects `/proc/meminfo`'s `HugePages_Total` value.
-/// On Windows it queries `GetLargePageMinimum`.
-pub fn huge_pages_enabled() -> bool {
-    #[cfg(target_os = "linux")]
-    {
-        if let Ok(meminfo) = std::fs::read_to_string("/proc/meminfo") {
-            return parse_hugepages_total(&meminfo);
+#[cfg(target_os = "windows")]
+use std::{mem, ptr, slice};
+
+#[cfg(target_os = "windows")]
+use windows_sys::Win32::Foundation::{
+    CloseHandle, GetLastError, ERROR_INSUFFICIENT_BUFFER, ERROR_SUCCESS, HANDLE,
+};
+#[cfg(target_os = "windows")]
+use windows_sys::Win32::Security::{
+    AdjustTokenPrivileges, GetTokenInformation, LookupPrivilegeValueW, TokenPrivileges, LUID,
+    LUID_AND_ATTRIBUTES, SE_PRIVILEGE_ENABLED, SE_PRIVILEGE_ENABLED_BY_DEFAULT,
+    TOKEN_ADJUST_PRIVILEGES, TOKEN_PRIVILEGES, TOKEN_QUERY,
+};
+#[cfg(target_os = "windows")]
+use windows_sys::Win32::System::Memory::GetLargePageMinimum;
+#[cfg(target_os = "windows")]
+use windows_sys::Win32::System::SystemServices::SE_LOCK_MEMORY_NAME;
+#[cfg(target_os = "windows")]
+use windows_sys::Win32::System::Threading::{GetCurrentProcess, OpenProcessToken};
+
+/// Size of the RandomX dataset in bytes when running in fast (full memory) mode.
+pub const RANDOMX_DATASET_BYTES: u64 = 2_u64 * 1024 * 1024 * 1024; // ~2 GiB
+/// Approximate per-thread scratchpad size required by RandomX.
+pub const RANDOMX_SCRATCHPAD_BYTES: u64 = 2_u64 * 1024 * 1024; // ~2 MiB
+
+/// Information about the system's huge/large page configuration.
+#[derive(Debug, Clone, Default)]
+pub struct HugePageStatus {
+    pub supported: bool,
+    pub has_privilege: bool,
+    pub page_size_bytes: Option<u64>,
+    pub total_bytes: Option<u64>,
+    pub free_bytes: Option<u64>,
+}
+
+impl HugePageStatus {
+    /// Whether the operating system reports that huge/large pages can be used right now.
+    pub fn enabled(&self) -> bool {
+        if !self.supported || !self.has_privilege {
+            return false;
         }
-        false
+        match self.free_bytes {
+            Some(0) => false,
+            _ => true,
+        }
     }
-    #[cfg(target_os = "windows")]
-    {
-        // windows-sys with feature Win32_System_Memory
-        use windows_sys::Win32::System::Memory::GetLargePageMinimum;
-        unsafe { GetLargePageMinimum() > 0 }
-    }
-    #[cfg(not(any(target_os = "linux", target_os = "windows")))]
-    {
-        false
+
+    /// Check whether the supplied allocation size can fit entirely within the available huge pages.
+    pub fn dataset_fits(&self, bytes: u64) -> bool {
+        if !self.enabled() {
+            return false;
+        }
+        if let Some(page) = self.page_size_bytes {
+            if bytes % page != 0 {
+                return false;
+            }
+        }
+        match self.free_bytes {
+            Some(available) => available >= bytes,
+            None => true, // capacity unknown (Windows does not expose a simple query)
+        }
     }
 }
 
+/// Return the current huge/large page status for the host platform.
+pub fn huge_page_status() -> HugePageStatus {
+    #[cfg(target_os = "linux")]
+    {
+        return linux_huge_page_status();
+    }
+    #[cfg(target_os = "windows")]
+    {
+        return windows_huge_page_status();
+    }
+    #[cfg(not(any(target_os = "linux", target_os = "windows")))]
+    {
+        HugePageStatus::default()
+    }
+}
+
+/// Check if operating system has huge pages / large pages available and ready for use.
+pub fn huge_pages_enabled() -> bool {
+    huge_page_status().enabled()
+}
+
 #[cfg(target_os = "linux")]
-fn parse_hugepages_total(meminfo: &str) -> bool {
+fn linux_huge_page_status() -> HugePageStatus {
+    if let Ok(meminfo) = std::fs::read_to_string("/proc/meminfo") {
+        if let Some(mut status) = parse_huge_page_info(&meminfo) {
+            // When HugePages_Total == 0 we still want to expose the page size (if available).
+            if status.page_size_bytes.is_none() {
+                status.page_size_bytes = parse_meminfo_value(&meminfo, "Hugepagesize:")
+                    .map(|kb| kb.saturating_mul(1024));
+            }
+            return status;
+        }
+    }
+    HugePageStatus::default()
+}
+
+#[cfg(target_os = "linux")]
+fn parse_huge_page_info(meminfo: &str) -> Option<HugePageStatus> {
+    let total = parse_meminfo_value(meminfo, "HugePages_Total:")?;
+    let free = parse_meminfo_value(meminfo, "HugePages_Free:").unwrap_or(0);
+    let reserved = parse_meminfo_value(meminfo, "HugePages_Rsvd:").unwrap_or(0);
+    let size_kb = parse_meminfo_value(meminfo, "Hugepagesize:")?;
+    let page_bytes = size_kb.saturating_mul(1024);
+    let free_pages = free.saturating_sub(reserved);
+    Some(HugePageStatus {
+        supported: total > 0,
+        has_privilege: true,
+        page_size_bytes: Some(page_bytes),
+        total_bytes: Some(total.saturating_mul(page_bytes)),
+        free_bytes: Some(free_pages.saturating_mul(page_bytes)),
+    })
+}
+
+#[cfg(target_os = "linux")]
+fn parse_meminfo_value(meminfo: &str, needle: &str) -> Option<u64> {
     for line in meminfo.lines() {
-        if let Some(rest) = line.strip_prefix("HugePages_Total:") {
-            if let Some(total) = rest.trim().split_whitespace().next() {
-                if let Ok(v) = total.parse::<u64>() {
-                    return v > 0;
+        if let Some(rest) = line.strip_prefix(needle) {
+            if let Some(value) = rest.trim().split_whitespace().next() {
+                if let Ok(parsed) = value.parse::<u64>() {
+                    return Some(parsed);
                 }
             }
         }
     }
-    false
+    None
+}
+
+#[cfg(target_os = "windows")]
+fn windows_huge_page_status() -> HugePageStatus {
+    unsafe {
+        let page_min = GetLargePageMinimum();
+        if page_min == 0 {
+            return HugePageStatus::default();
+        }
+        HugePageStatus {
+            supported: true,
+            has_privilege: has_lock_memory_privilege(),
+            page_size_bytes: Some(page_min as u64),
+            total_bytes: None,
+            free_bytes: None,
+        }
+    }
+}
+
+/// Attempt to ensure the process token has the SeLockMemoryPrivilege enabled on Windows.
+/// On non-Windows platforms this is a no-op that returns true.
+pub fn enable_large_page_privilege() -> bool {
+    #[cfg(target_os = "windows")]
+    {
+        enable_lock_memory_privilege()
+    }
+    #[cfg(not(target_os = "windows"))]
+    {
+        true
+    }
+}
+
+#[cfg(target_os = "windows")]
+fn enable_lock_memory_privilege() -> bool {
+    unsafe {
+        if has_lock_memory_privilege() {
+            return true;
+        }
+
+        let mut token: HANDLE = 0;
+        if OpenProcessToken(
+            GetCurrentProcess(),
+            TOKEN_ADJUST_PRIVILEGES | TOKEN_QUERY,
+            &mut token,
+        ) == 0
+        {
+            return false;
+        }
+
+        let mut luid: LUID = mem::zeroed();
+        if LookupPrivilegeValueW(ptr::null(), SE_LOCK_MEMORY_NAME, &mut luid) == 0 {
+            CloseHandle(token);
+            return false;
+        }
+
+        let mut privileges = TOKEN_PRIVILEGES {
+            PrivilegeCount: 1,
+            Privileges: [LUID_AND_ATTRIBUTES {
+                Luid: luid,
+                Attributes: SE_PRIVILEGE_ENABLED,
+            }],
+        };
+
+        let adjust_result = AdjustTokenPrivileges(
+            token,
+            0,
+            &mut privileges,
+            0,
+            ptr::null_mut(),
+            ptr::null_mut(),
+        );
+        let last_error = GetLastError();
+        CloseHandle(token);
+
+        if adjust_result == 0 {
+            return false;
+        }
+
+        if last_error != ERROR_SUCCESS {
+            return false;
+        }
+
+        // Confirm the privilege is now active.
+        has_lock_memory_privilege()
+    }
+}
+
+#[cfg(target_os = "windows")]
+fn has_lock_memory_privilege() -> bool {
+    unsafe {
+        let mut token: HANDLE = 0;
+        if OpenProcessToken(GetCurrentProcess(), TOKEN_QUERY, &mut token) == 0 {
+            return false;
+        }
+
+        let mut luid: LUID = mem::zeroed();
+        if LookupPrivilegeValueW(ptr::null(), SE_LOCK_MEMORY_NAME, &mut luid) == 0 {
+            CloseHandle(token);
+            return false;
+        }
+
+        let mut required_len: u32 = 0;
+        GetTokenInformation(
+            token,
+            TokenPrivileges,
+            ptr::null_mut(),
+            0,
+            &mut required_len,
+        );
+        if GetLastError() != ERROR_INSUFFICIENT_BUFFER {
+            CloseHandle(token);
+            return false;
+        }
+
+        let mut buffer = vec![0u8; required_len as usize];
+        if GetTokenInformation(
+            token,
+            TokenPrivileges,
+            buffer.as_mut_ptr().cast(),
+            required_len,
+            &mut required_len,
+        ) == 0
+        {
+            CloseHandle(token);
+            return false;
+        }
+
+        let token_privileges = buffer.as_ptr() as *const TOKEN_PRIVILEGES;
+        let count = (*token_privileges).PrivilegeCount as usize;
+        let privileges_ptr = (*token_privileges).Privileges.as_ptr();
+        let privileges = slice::from_raw_parts(privileges_ptr, count);
+        let mut has_priv = false;
+        for privilege in privileges {
+            if privilege.Luid.LowPart == luid.LowPart && privilege.Luid.HighPart == luid.HighPart {
+                let enabled_mask = SE_PRIVILEGE_ENABLED | SE_PRIVILEGE_ENABLED_BY_DEFAULT;
+                if (privilege.Attributes & enabled_mask) != 0 {
+                    has_priv = true;
+                }
+                break;
+            }
+        }
+
+        CloseHandle(token);
+        has_priv
+    }
 }
 
 /// Determine whether the current CPU supports AES instructions (x86/x86_64).
@@ -66,10 +305,10 @@ fn l3_cache_bytes() -> Option<usize> {
             if cache.level() == 3 && matches!(cache.cache_type(), raw_cpuid::CacheType::Unified) {
                 // CPUID leaf 0x4 size formula:
                 // size = associativity * partitions * line_size * sets
-                let ways  = cache.associativity() as usize;
+                let ways = cache.associativity() as usize;
                 let parts = cache.physical_line_partitions() as usize;
-                let line  = cache.coherency_line_size() as usize;
-                let sets  = cache.sets() as usize;
+                let line = cache.coherency_line_size() as usize;
+                let sets = cache.sets() as usize;
                 return Some(ways * parts * line * sets);
             }
         }
@@ -89,6 +328,7 @@ pub struct AutoTuneSnapshot {
     pub available_bytes: u64,
     pub dataset_bytes: u64,
     pub scratch_per_thread_bytes: u64,
+    pub huge_page_status: HugePageStatus,
     pub suggested_threads: usize,
 }
 
@@ -107,14 +347,19 @@ pub fn autotune_snapshot() -> AutoTuneSnapshot {
     let avail_bytes = sys.available_memory();
 
     // RandomX "fast" dataset and per-thread scratchpad estimates
-    let dataset = 2_u64 * 1024 * 1024 * 1024; // ~2 GiB
-    let scratch = 2_u64 * 1024 * 1024;        // ~2 MiB per thread
+    let dataset = RANDOMX_DATASET_BYTES;
+    let scratch = RANDOMX_SCRATCHPAD_BYTES;
+    let huge_pages = huge_page_status();
 
     let mut threads = physical;
 
     // L3 clamp (~2 MiB per thread)
     if let Some(l3b) = l3 {
-        let l3_per_thread = if l3b > 64 * 1024 * 1024 { 4 * 1024 * 1024 } else { 2 * 1024 * 1024 };
+        let l3_per_thread = if l3b > 64 * 1024 * 1024 {
+            4 * 1024 * 1024
+        } else {
+            2 * 1024 * 1024
+        };
         let cache_threads = (l3b / l3_per_thread).max(1);
         threads = threads.min(cache_threads);
     }
@@ -133,6 +378,7 @@ pub fn autotune_snapshot() -> AutoTuneSnapshot {
         available_bytes: avail_bytes,
         dataset_bytes: dataset,
         scratch_per_thread_bytes: scratch,
+        huge_page_status: huge_pages,
         suggested_threads: threads.max(1),
     }
 }
@@ -148,13 +394,21 @@ mod tests {
 
     #[cfg(target_os = "linux")]
     #[test]
-    fn parses_hugepages_total() {
-        let enabled = "HugePages_Total:       5\nOther: 0";
-        assert!(parse_hugepages_total(enabled));
-        let disabled = "HugePages_Total:       0\nOther: 0";
-        assert!(!parse_hugepages_total(disabled));
+    fn parses_hugepage_info() {
+        let enabled = "HugePages_Total:       5\nHugePages_Free:        3\nHugePages_Rsvd:        1\nHugepagesize:       2048 kB";
+        let status = parse_huge_page_info(enabled).expect("hugepage info");
+        assert!(status.supported);
+        assert_eq!(status.page_size_bytes, Some(2048 * 1024));
+        // free_pages = 3 - 1 = 2 -> bytes = 2 * 2048 KiB
+        assert_eq!(status.free_bytes, Some(2 * 2048 * 1024));
+
+        let disabled =
+            "HugePages_Total:       0\nHugePages_Free:        0\nHugepagesize:       2048 kB";
+        let status = parse_huge_page_info(disabled).expect("hugepage info");
+        assert!(!status.supported);
+
         let missing = "SomethingElse: 1";
-        assert!(!parse_hugepages_total(missing));
+        assert!(parse_huge_page_info(missing).is_none());
     }
 
     #[test]
@@ -167,5 +421,6 @@ mod tests {
     fn feature_checks_do_not_panic() {
         let _ = cpu_has_aes();
         let _ = huge_pages_enabled();
+        let _ = huge_page_status();
     }
 }

--- a/crates/oxide-core/src/worker.rs
+++ b/crates/oxide-core/src/worker.rs
@@ -1,5 +1,8 @@
 use anyhow::Result;
-use std::sync::{Arc, atomic::{AtomicU64, Ordering}};
+use std::sync::{
+    atomic::{AtomicU64, Ordering},
+    Arc,
+};
 use std::time::{SystemTime, UNIX_EPOCH};
 use tokio::sync::{broadcast, mpsc};
 
@@ -31,7 +34,7 @@ pub fn spawn_workers(
     hash_counter: Arc<AtomicU64>,
 ) -> Vec<tokio::task::JoinHandle<()>> {
     #[cfg(feature = "randomx")]
-    engine::set_large_pages(large_pages);
+    let _ = engine::set_large_pages(large_pages);
     let core_ids = if affinity {
         core_affinity::get_core_ids()
     } else {
@@ -79,7 +82,7 @@ pub fn spawn_workers(
 
 #[cfg(feature = "randomx")]
 mod engine {
-    use crate::system;
+    use crate::system::{self, RANDOMX_DATASET_BYTES};
     use anyhow::Result;
     use randomx_rs::{RandomXCache, RandomXDataset, RandomXFlag, RandomXVM};
     use std::{
@@ -113,8 +116,56 @@ mod engine {
     // randomx-rs exposes FLAG_* constants.
     static LARGE_PAGES: AtomicBool = AtomicBool::new(false);
 
-    pub fn set_large_pages(enable: bool) {
-        LARGE_PAGES.store(enable, Ordering::Relaxed);
+    pub fn set_large_pages(enable: bool) -> bool {
+        if !enable {
+            LARGE_PAGES.store(false, Ordering::Relaxed);
+            return false;
+        }
+
+        let mut status = system::huge_page_status();
+        if !status.supported {
+            tracing::warn!("Large pages requested but the operating system does not report support; continuing without them");
+            LARGE_PAGES.store(false, Ordering::Relaxed);
+            return false;
+        }
+
+        if !status.has_privilege {
+            if !system::enable_large_page_privilege() {
+                tracing::warn!("Large pages requested but unable to enable required privileges; continuing without large pages");
+                LARGE_PAGES.store(false, Ordering::Relaxed);
+                return false;
+            }
+            status = system::huge_page_status();
+        }
+
+        if !status.enabled() {
+            let free = status.free_bytes.unwrap_or(0);
+            tracing::warn!(
+                free_bytes = free,
+                "Large pages requested but none are currently available; continuing without large pages",
+            );
+            LARGE_PAGES.store(false, Ordering::Relaxed);
+            return false;
+        }
+
+        if !status.dataset_fits(RANDOMX_DATASET_BYTES) {
+            let free = status.free_bytes.unwrap_or(0);
+            tracing::warn!(
+                free_bytes = free,
+                required_bytes = RANDOMX_DATASET_BYTES,
+                "Large pages requested but available huge pages cannot accommodate the RandomX dataset; continuing without large pages",
+            );
+            LARGE_PAGES.store(false, Ordering::Relaxed);
+            return false;
+        }
+
+        LARGE_PAGES.store(true, Ordering::Relaxed);
+        if let Some(page) = status.page_size_bytes {
+            tracing::info!(page_size_bytes = page, "RandomX large pages enabled",);
+        } else {
+            tracing::info!("RandomX large pages enabled");
+        }
+        true
     }
 
     fn default_flags() -> RandomXFlag {
@@ -442,15 +493,24 @@ fn meets_target(hash: &[u8; 32], job: &PoolJob) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::{atomic::AtomicU64, Arc};
     use tokio::sync::{broadcast, mpsc};
-    use std::sync::{Arc, atomic::AtomicU64};
 
     #[tokio::test]
     async fn spawns_correct_number_of_workers() {
         let (jobs_tx, _jobs_rx) = broadcast::channel(1);
         let (shares_tx, _shares_rx) = mpsc::unbounded_channel();
         let hash_counter = Arc::new(AtomicU64::new(0));
-        let handles = spawn_workers(3, jobs_tx, shares_tx, false, false, 10_000, true, hash_counter);
+        let handles = spawn_workers(
+            3,
+            jobs_tx,
+            shares_tx,
+            false,
+            false,
+            10_000,
+            true,
+            hash_counter,
+        );
         assert_eq!(handles.len(), 3);
         for h in handles {
             h.abort();

--- a/crates/oxide-miner/src/main.rs
+++ b/crates/oxide-miner/src/main.rs
@@ -1,8 +1,8 @@
 mod args;
 mod http_api;
 mod miner;
-mod util;
 mod stats;
+mod util;
 
 use anyhow::Result;
 use args::Args;

--- a/crates/oxide-miner/src/miner.rs
+++ b/crates/oxide-miner/src/miner.rs
@@ -5,7 +5,7 @@ use crate::util::tiny_jitter_ms;
 use anyhow::Result;
 use oxide_core::worker::{Share, WorkItem};
 use oxide_core::{
-    autotune_snapshot, cpu_has_aes, huge_pages_enabled, spawn_workers, Config, DevFeeScheduler,
+    autotune_snapshot, cpu_has_aes, spawn_workers, Config, DevFeeScheduler, HugePageStatus,
     StratumClient, DEV_FEE_BASIS_POINTS, DEV_WALLET_ADDRESS,
 };
 use std::collections::{HashMap, HashSet};
@@ -60,13 +60,13 @@ pub async fn run(args: Args) -> Result<()> {
     // ----------------------------------------------------------
 
     if args.benchmark {
-        let hp_supported = huge_pages_enabled();
-        if args.huge_pages && !hp_supported {
-            tracing::warn!("Huge pages are NOT enabled; RandomX performance may be reduced.");
-        }
         let snap = autotune_snapshot();
+        let hp_status = snap.huge_page_status.clone();
+        if args.huge_pages && !hp_status.dataset_fits(snap.dataset_bytes) {
+            warn_huge_page_limit(&hp_status, snap.dataset_bytes);
+        }
         let n_workers = args.threads.unwrap_or(snap.suggested_threads);
-        let large_pages = args.huge_pages && hp_supported;
+        let large_pages = args.huge_pages && hp_status.dataset_fits(snap.dataset_bytes);
         tracing::info!(
             "benchmark: threads={} batch_size={} large_pages={} yield={}",
             n_workers,
@@ -98,17 +98,12 @@ pub async fn run(args: Args) -> Result<()> {
         agent: format!("OxideMiner/{}", env!("CARGO_PKG_VERSION")),
     };
 
-    // Detect huge/large pages and warn once if not present
-    let hp_supported = huge_pages_enabled();
-    if !hp_supported {
-        tracing::warn!(
-            "Huge pages are NOT enabled; RandomX performance may be reduced. \
-            Linux: configure vm.nr_hugepages; Windows: enable 'Lock pages in memory' and Large Pages."
-        );
-    }
-
     // Take snapshot to log how auto-tune decided thread count
     let snap = autotune_snapshot();
+    let hp_status = snap.huge_page_status.clone();
+    if !hp_status.enabled() {
+        warn_huge_page_limit(&hp_status, snap.dataset_bytes);
+    }
     let auto_threads = snap.suggested_threads;
     let n_workers = cfg.threads.unwrap_or(auto_threads);
 
@@ -118,7 +113,10 @@ pub async fn run(args: Args) -> Result<()> {
     let aes = cpu_has_aes();
 
     // If spawn call passes a 'large_pages' boolean, prefer user opt-in AND OS support
-    let large_pages = cfg.huge_pages && hp_supported;
+    let large_pages = cfg.huge_pages && hp_status.dataset_fits(snap.dataset_bytes);
+    if cfg.huge_pages && !large_pages && hp_status.enabled() {
+        warn_huge_page_limit(&hp_status, snap.dataset_bytes);
+    }
 
     if let Some(user_t) = cfg.threads {
         tracing::info!(
@@ -147,10 +145,6 @@ pub async fn run(args: Args) -> Result<()> {
     let (jobs_tx, _jobs_rx0) = tokio::sync::broadcast::channel(64);
     // MPSC: shares <- workers
     let (shares_tx, mut shares_rx) = tokio::sync::mpsc::unbounded_channel::<Share>();
-
-    if !huge_pages_enabled() {
-        tracing::warn!("huge pages are not enabled; mining performance may be reduced");
-    }
 
     if cfg.threads.is_none() {
         tracing::info!("auto-selected {} worker threads", n_workers);
@@ -416,4 +410,30 @@ pub async fn run(args: Args) -> Result<()> {
     }
 
     Ok(())
+}
+
+fn warn_huge_page_limit(status: &HugePageStatus, dataset_bytes: u64) {
+    if !status.supported {
+        tracing::warn!(
+            "Huge pages are NOT enabled; RandomX performance may be reduced. \
+            Linux: configure vm.nr_hugepages; Windows: enable 'Lock pages in memory' and Large Pages."
+        );
+    } else if !status.has_privilege {
+        tracing::warn!(
+            "Huge pages support detected but the current process lacks permission. \
+            Windows: grant the 'Lock pages in memory' privilege to the user running OxideMiner."
+        );
+    } else if !status.enabled() {
+        tracing::warn!(
+            "Huge pages are configured but no free huge pages are available. \
+            Reserve huge pages via vm.nr_hugepages before starting the miner."
+        );
+    } else if !status.dataset_fits(dataset_bytes) {
+        let free = status.free_bytes.unwrap_or(0);
+        tracing::warn!(
+            free_bytes = free,
+            required_bytes = dataset_bytes,
+            "Huge page pool is too small for the RandomX dataset; continuing without huge pages",
+        );
+    }
 }


### PR DESCRIPTION
## Summary
- add HugePageStatus helpers to detect huge/large page support, enable Windows privileges, and surface the status through autotuning snapshots
- tighten RandomX worker setup so large pages are only requested when privileges and huge page capacity are available, logging successes and fallbacks
- plumb huge page status through the miner CLI and benchmark path to warn users when huge pages are unavailable or insufficient
- align the windows-sys feature set and imports with the Windows security APIs used by the huge page privilege helpers

## Testing
- cargo check
- cargo test


------
https://chatgpt.com/codex/tasks/task_e_68cf6917efe48333900417bad1bc0f2e