### PR TITLE
Share RandomX dataset across workers

### DIFF
--- a/crates/oxide-core/src/benchmark.rs
+++ b/crates/oxide-core/src/benchmark.rs
@@ -25,18 +25,19 @@ pub async fn run_benchmark(
     let duration = Duration::from_secs(seconds);
     let threads_u32 = threads as u32;
 
+    let seed = [0u8; 32];
+    let (shared_cache, shared_dataset) = ensure_fullmem_dataset(&seed, threads_u32)?;
+
     let mut handles: Vec<task::JoinHandle<Result<u64>>> = Vec::new();
     for id in 0..threads {
         let duration = duration;
         let batch_size = batch_size;
         let threads_u32 = threads_u32;
         let yield_between_batches = yield_between_batches;
+        let cache = shared_cache.clone();
+        let dataset = shared_dataset.clone();
         handles.push(task::spawn(async move {
-            let seed = [0u8; 32];
-            let vm = {
-                let (cache, dataset) = ensure_fullmem_dataset(&seed, threads_u32)?;
-                create_vm_for_dataset(&cache, &dataset, None)?
-            };
+            let vm = create_vm_for_dataset(&cache, &dataset, None)?;
             let mut blob = vec![0u8; 43];
             let mut nonce = id as u32;
             let start = Instant::now();


### PR DESCRIPTION
## Summary
- add process-wide RandomX cache/dataset storage guarded by a global lock so every worker reuses the same allocation
- mark the cache and dataset wrappers as safe to share and adjust the benchmark to reuse the shared dataset across spawned tasks

## Testing
- cargo check
- cargo test

------
https://chatgpt.com/codex/tasks/task_e_68d20566fbf8833390f0dc3e1ab23388