### PR TITLE
Share RandomX dataset across worker threads

### DIFF
--- a/crates/oxide-core/src/benchmark.rs
+++ b/crates/oxide-core/src/benchmark.rs
@@ -34,7 +34,7 @@ pub async fn run_benchmark(
         handles.push(task::spawn(async move {
             let seed = [0u8; 32];
             let vm = {
-                let (cache, dataset) = ensure_fullmem_dataset(&seed, threads_u32)?;
+                let (cache, dataset) = ensure_fullmem_dataset(&seed, threads_u32).await?;
                 create_vm_for_dataset(&cache, &dataset, None)?
             };
             let mut blob = vec![0u8; 43];


### PR DESCRIPTION
## Summary
- reuse a single RandomX cache+dataset across all workers using a global Lazy Mutex so only one 2GB allocation occurs per seed hash
- mark the cache and dataset wrappers as Send/Sync and update worker/benchmark code to await the shared dataset when seeds change

## Testing
- `cargo check`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68d20566fbf8833390f0dc3e1ab23388