### PR TITLE
Fix RandomX benchmark to measure real hash throughput

### DIFF
--- a/crates/oxide-core/src/benchmark.rs
+++ b/crates/oxide-core/src/benchmark.rs
@@ -12,6 +12,20 @@ use tokio::task;
 #[cfg(feature = "randomx")]
 use crate::worker::{create_vm_for_dataset, ensure_fullmem_dataset, hash, set_large_pages};
 
+#[cfg(feature = "randomx")]
+const BENCHMARK_BLOB_TEMPLATE: [u8; 76] = [
+    // Major/minor version (varint encoded), timestamp and part of the previous block hash.
+    0x0c, 0x0c, 0x0b, 0xa9, 0xb0, 0xd6, 0x5d, 0x92, 0x4f, 0x8a, 0x23, 0x11, 0xa7, 0x9c, 0x4f, 0xd0,
+    0x58, 0x84, 0x63, 0x1b, 0x4a, 0xc0, 0x1c, 0x8b, 0x7e, 0x90, 0x3d, 0xcc, 0xff, 0x1a, 0xbb, 0x75,
+    0x09, 0x42, 0x97, 0x31, 0x6f, 0xe1, 0x58,
+    // Nonce (overwritten per hash to emulate miner behaviour).
+    0x00, 0x00, 0x00, 0x00,
+    // Remainder of the block template (merkle root, tx count, etc.).
+    0x6a, 0x02, 0x10, 0x3c, 0xdd, 0x4b, 0xe6, 0x99, 0x51, 0xab, 0xcd, 0xef, 0x03, 0x20, 0x11, 0x05,
+    0xd4, 0x38, 0x8c, 0xa0, 0xfe, 0x55, 0x90, 0x72, 0x63, 0x44, 0x21, 0x7a, 0xb2, 0x6f, 0x19, 0x80,
+    0x01,
+];
+
 /// Run a simple RandomX benchmark and return hashes per second.
 #[cfg(feature = "randomx")]
 pub async fn run_benchmark(
@@ -21,6 +35,10 @@ pub async fn run_benchmark(
     batch_size: usize,
     yield_between_batches: bool,
 ) -> Result<f64> {
+    if seconds == 0 || threads == 0 || batch_size == 0 {
+        return Ok(0.0);
+    }
+
     let _ = set_large_pages(large_pages);
     let duration = Duration::from_secs(seconds);
     let threads_u32 = threads as u32;
@@ -38,23 +56,50 @@ pub async fn run_benchmark(
         let dataset = shared_dataset.clone();
         handles.push(task::spawn(async move {
             let vm = create_vm_for_dataset(&cache, &dataset, None)?;
-            let mut blob = vec![0u8; 43];
+            let mut blob = BENCHMARK_BLOB_TEMPLATE;
             let mut nonce = id as u32;
             let start = Instant::now();
-            let mut hashes: u64 = 0;
-            while start.elapsed() < duration {
+            let mut total_hashes: u64 = 0;
+            let mut now = start;
+            let deadline = start + duration;
+
+            while now < deadline {
+                let mut batch_hashes: u64 = 0;
                 for _ in 0..batch_size {
+                    if now >= deadline {
+                        break;
+                    }
                     // write nonce at offset 39
                     blob[39..43].copy_from_slice(&nonce.to_le_bytes());
-                    let _ = hash(&vm, &blob);
+                    let _digest = hash(&vm, &blob);
+                    total_hashes += 1;
+                    batch_hashes += 1;
                     nonce = nonce.wrapping_add(threads_u32);
+                    now = Instant::now();
                 }
-                hashes += batch_size as u64;
+
+                if batch_hashes > 0 {
+                    let elapsed_secs = now.duration_since(start).as_secs_f64();
+                    tracing::debug!(
+                        worker = id,
+                        elapsed_secs,
+                        batch_hashes,
+                        total_hashes,
+                        "benchmark progress"
+                    );
+                }
+
+                if now >= deadline {
+                    break;
+                }
+
                 if yield_between_batches {
                     task::yield_now().await;
+                    now = Instant::now();
                 }
             }
-            Ok(hashes)
+
+            Ok(total_hashes)
         }));
     }
 
@@ -62,7 +107,7 @@ pub async fn run_benchmark(
     for h in handles {
         total += h.await??;
     }
-    Ok(total as f64 / seconds as f64)
+    Ok(total as f64 / duration.as_secs_f64())
 }
 
 #[cfg(not(feature = "randomx"))]


### PR DESCRIPTION
## Summary
- seed the benchmark with a realistic RandomX block header template and ignore zero-length runs
- drive each worker against a fixed deadline while counting every hash invocation and updating the nonce
- emit per-batch debug logs to expose per-thread throughput during the run

## Testing
- cargo check --workspace

------
https://chatgpt.com/codex/tasks/task_e_68d2f834956c833389b06562ffb67524