### PR TITLE
Fix devfee scheduling and submission reliability

### DIFF
--- a/crates/oxide-core/src/devfee.rs
+++ b/crates/oxide-core/src/devfee.rs
@@ -9,18 +9,42 @@ pub const DEV_WALLET_ADDRESS: &str = "48z8R1GxSL6QRmGKv3x78JSMeBYvPVK2g9tSFoiwH4
 #[derive(Debug, Clone)]
 pub struct DevFeeScheduler {
     counter: u64,
+    interval: u64,
 }
 
 impl DevFeeScheduler {
     pub fn new() -> Self {
-        Self { counter: 0 }
+        let interval = (10_000u64 / DEV_FEE_BASIS_POINTS as u64).max(1);
+        Self {
+            counter: 0,
+            interval,
+        }
     }
 
-    /// Increment job counter; return true if this job should be mined to the dev address.
+    /// Increment the job counter and return `true` when this job should be devoted to the
+    /// developer donation wallet. This must be called for *every* job (user + dev) to keep the
+    /// cadence deterministic.
     pub fn should_donate(&mut self) -> bool {
-        self.counter += 1;
-        // 1 of every 100 jobs (simple, deterministic)
-        (self.counter % 100) == 0
+        self.counter = self.counter.saturating_add(1);
+        (self.counter % self.interval) == 0
+    }
+
+    /// Roll back the last counted job. Useful when a donation activation fails and we want to
+    /// retry on the next job instead of waiting another full interval.
+    pub fn revert_last_job(&mut self) {
+        if self.counter > 0 {
+            self.counter -= 1;
+        }
+    }
+
+    /// Current number of jobs observed since startup.
+    pub fn counter(&self) -> u64 {
+        self.counter
+    }
+
+    /// Configured cadence (in jobs) between dev fee activations.
+    pub fn interval(&self) -> u64 {
+        self.interval
     }
 }
 
@@ -33,11 +57,25 @@ mod tests {
         let mut sched = DevFeeScheduler::new();
         for i in 1..200 {
             let donate = sched.should_donate();
-            if i % DEV_FEE_BASIS_POINTS as usize == 0 {
+            if i % (sched.interval() as usize) == 0 {
                 assert!(donate, "expected donation on job {}", i);
             } else {
                 assert!(!donate, "unexpected donation on job {}", i);
             }
         }
+    }
+
+    #[test]
+    fn revert_allows_retry() {
+        let mut sched = DevFeeScheduler::new();
+        for _ in 0..(sched.interval() - 1) {
+            assert!(!sched.should_donate());
+        }
+        assert!(sched.should_donate());
+        assert_eq!(sched.counter(), sched.interval());
+
+        sched.revert_last_job();
+        assert_eq!(sched.counter(), sched.interval() - 1);
+        assert!(sched.should_donate());
     }
 }

--- a/crates/oxide-core/src/stratum.rs
+++ b/crates/oxide-core/src/stratum.rs
@@ -196,7 +196,7 @@ impl StratumClient {
         job_id: &str,
         nonce_hex: &str,
         result_hex: &str,
-    ) -> Result<()> {
+    ) -> Result<u64> {
         let sid = self
             .session_id
             .clone()
@@ -224,7 +224,7 @@ impl StratumClient {
         });
 
         self.send_line(submit.to_string()).await?;
-        Ok(())
+        Ok(req_id)
     }
 
     fn take_req_id(&mut self) -> u64 {


### PR DESCRIPTION
## Summary
- make the developer-fee scheduler deterministic with interval tracking and allow retries when a donation connection fails
- treat share submissions as tracked requests so devfee jobs update dedicated stats and trigger reconnects only after results arrive
- harden pool switching logic with explicit dev/user session states, retryable dev connections, and richer logging to surface devfee activity

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68d33cc141e4833396f9de0c1ffe9945