### PR TITLE
Fix devfee scheduling and share accounting

### DIFF
--- a/crates/oxide-core/src/devfee.rs
+++ b/crates/oxide-core/src/devfee.rs
@@ -8,19 +8,58 @@ pub const DEV_WALLET_ADDRESS: &str = "48z8R1GxSL6QRmGKv3x78JSMeBYvPVK2g9tSFoiwH4
 
 #[derive(Debug, Clone)]
 pub struct DevFeeScheduler {
-    counter: u64,
+    /// Total jobs observed since startup (user + dev).
+    observed_jobs: u64,
+    /// Jobs counted toward the next donation window.
+    counter: u32,
+    /// When true we still owe a donation share (e.g. after a failed attempt).
+    pending: bool,
 }
 
 impl DevFeeScheduler {
     pub fn new() -> Self {
-        Self { counter: 0 }
+        Self {
+            observed_jobs: 0,
+            counter: 0,
+            pending: false,
+        }
     }
 
-    /// Increment job counter; return true if this job should be mined to the dev address.
+    /// Record that a new stratum job has been received. Returns `true` when
+    /// the caller should mine a developer donation share.
     pub fn should_donate(&mut self) -> bool {
+        self.observed_jobs = self.observed_jobs.saturating_add(1);
+
+        if self.pending {
+            return true;
+        }
+
         self.counter += 1;
-        // 1 of every 100 jobs (simple, deterministic)
-        (self.counter % 100) == 0
+        if self.counter >= DEV_FEE_BASIS_POINTS {
+            self.pending = true;
+            true
+        } else {
+            false
+        }
+    }
+
+    /// Mark that we have successfully switched to the dev wallet so the
+    /// scheduler can start counting the next window.
+    pub fn mark_started(&mut self) {
+        if self.pending {
+            self.pending = false;
+            self.counter = 0;
+        }
+    }
+
+    /// Total jobs observed since the miner started.
+    pub fn observed_jobs(&self) -> u64 {
+        self.observed_jobs
+    }
+
+    /// Whether a donation share is still pending.
+    pub fn pending(&self) -> bool {
+        self.pending
     }
 }
 
@@ -31,13 +70,30 @@ mod tests {
     #[test]
     fn donate_every_hundred() {
         let mut sched = DevFeeScheduler::new();
-        for i in 1..200 {
+        for i in 1..=200 {
             let donate = sched.should_donate();
             if i % DEV_FEE_BASIS_POINTS as usize == 0 {
                 assert!(donate, "expected donation on job {}", i);
+                sched.mark_started();
             } else {
                 assert!(!donate, "unexpected donation on job {}", i);
             }
         }
+        assert_eq!(sched.observed_jobs(), 200);
+    }
+
+    #[test]
+    fn donation_stays_pending_until_started() {
+        let mut sched = DevFeeScheduler::new();
+        for _ in 0..(DEV_FEE_BASIS_POINTS - 1) {
+            assert!(!sched.should_donate());
+        }
+        assert!(sched.should_donate());
+        assert!(sched.pending());
+        // Still pending on subsequent jobs until mark_started is called.
+        assert!(sched.should_donate());
+        sched.mark_started();
+        assert!(!sched.pending());
+        assert!(!sched.should_donate());
     }
 }

--- a/crates/oxide-core/src/stratum.rs
+++ b/crates/oxide-core/src/stratum.rs
@@ -196,7 +196,7 @@ impl StratumClient {
         job_id: &str,
         nonce_hex: &str,
         result_hex: &str,
-    ) -> Result<()> {
+    ) -> Result<u64> {
         let sid = self
             .session_id
             .clone()
@@ -208,6 +208,7 @@ impl StratumClient {
             job_id = job_id,
             nonce_hex = nonce_hex,
             result_hex = result_hex,
+            req_id,
             "submit_share"
         );
 
@@ -224,7 +225,7 @@ impl StratumClient {
         });
 
         self.send_line(submit.to_string()).await?;
-        Ok(())
+        Ok(req_id)
     }
 
     fn take_req_id(&mut self) -> u64 {


### PR DESCRIPTION
## Summary
- persist developer fee scheduling state across jobs with new pending tracking and tests
- return stratum submit request identifiers and map share responses back to devfee submissions for accurate stats
- rework miner devfee handling to activate on login/job notifications, throttle duplicate donations, and reconnect to the user pool after a dev share

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68d33cc141e4833396f9de0c1ffe9945