### PR TITLE
Ensure devfee work is scheduled and tracked reliably

### DIFF
--- a/crates/oxide-core/src/stratum.rs
+++ b/crates/oxide-core/src/stratum.rs
@@ -191,12 +191,14 @@ impl StratumClient {
 
     /// Submit a share; response will be read by the main loop via `read_json()`.
     /// `nonce_hex` = 8 hex chars (LE), `result_hex` = 64 hex chars (LE).
+    /// Returns the JSON-RPC request id so callers can associate later responses
+    /// with the share submission.
     pub async fn submit_share(
         &mut self,
         job_id: &str,
         nonce_hex: &str,
         result_hex: &str,
-    ) -> Result<()> {
+    ) -> Result<u64> {
         let sid = self
             .session_id
             .clone()
@@ -224,7 +226,7 @@ impl StratumClient {
         });
 
         self.send_line(submit.to_string()).await?;
-        Ok(())
+        Ok(req_id)
     }
 
     fn take_req_id(&mut self) -> u64 {


### PR DESCRIPTION
## Summary
- return the JSON-RPC request id from `StratumClient::submit_share` so callers can correlate submit responses
- persist devfee scheduling across reconnects and only switch pools when required
- track in-flight devfee shares to update statistics and reconnect to the user pool once responses arrive, with additional logging for devfee activity

## Testing
- cargo fmt
- cargo test


------
https://chatgpt.com/codex/tasks/task_e_68d33cc141e4833396f9de0c1ffe9945