### PR TITLE
Add TLS pinning options and improve certificate handling

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,10 @@ windows-sys = { version = "0.61.0", features = [
     "Win32_System_SystemServices",
     "Win32_System_Threading",
 ] }
+rustls-pemfile = "1"
+ring = "0.17"
+rustls = { version = "0.21", features = ["dangerous_configuration"] }
+rustls_webpki = { package = "rustls-webpki", version = "0.101" }
 
 [profile.release]
 lto = true

--- a/crates/oxide-core/Cargo.toml
+++ b/crates/oxide-core/Cargo.toml
@@ -25,6 +25,10 @@ webpki-roots = { workspace = true }
 core_affinity = { workspace = true }
 sysinfo = { workspace = true }
 raw-cpuid = { workspace = true }
+rustls-pemfile = { workspace = true }
+ring = { workspace = true }
+rustls = { workspace = true }
+rustls_webpki = { workspace = true }
 
 [target.'cfg(target_os = "windows")'.dependencies]
 windows-sys = { workspace = true, features = [

--- a/crates/oxide-core/src/config.rs
+++ b/crates/oxide-core/src/config.rs
@@ -1,6 +1,7 @@
 // OxideMiner/crates/oxide-core/src/config.rs
 
 use serde::{Deserialize, Serialize};
+use std::path::PathBuf;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Config {
@@ -16,6 +17,10 @@ pub struct Config {
     pub enable_devfee: bool,
     /// enable TLS when connecting to the stratum pool
     pub tls: bool,
+    /// optional custom CA certificate to add to the trust store when TLS is enabled
+    pub tls_ca_cert: Option<PathBuf>,
+    /// optional pinned server certificate fingerprint (SHA-256)
+    pub tls_cert_sha256: Option<[u8; 32]>,
     /// optional HTTP API port for metrics (None disables)
     pub api_port: Option<u16>,
     /// pin worker threads to specific CPU cores
@@ -38,6 +43,8 @@ impl Default for Config {
             threads: None,
             enable_devfee: true,
             tls: false,
+            tls_ca_cert: None,
+            tls_cert_sha256: None,
             api_port: None,
             affinity: false,
             huge_pages: false,
@@ -60,6 +67,8 @@ mod tests {
         assert_eq!(cfg.pass.as_deref(), Some("x"));
         assert!(cfg.enable_devfee);
         assert!(!cfg.tls);
+        assert!(cfg.tls_ca_cert.is_none());
+        assert!(cfg.tls_cert_sha256.is_none());
         assert_eq!(cfg.api_port, None);
         assert!(!cfg.affinity);
         assert!(!cfg.huge_pages);

--- a/crates/oxide-miner/src/args.rs
+++ b/crates/oxide-miner/src/args.rs
@@ -34,6 +34,14 @@ pub struct Args {
     #[arg(long = "tls")]
     pub tls: bool,
 
+    /// Path to additional PEM/DER CA certificate to trust when using TLS
+    #[arg(long = "tls-ca-cert", value_name = "PATH")]
+    pub tls_ca_cert: Option<PathBuf>,
+
+    /// SHA-256 fingerprint of the expected TLS server certificate (hex)
+    #[arg(long = "tls-cert-sha256", value_name = "HEX")]
+    pub tls_cert_sha256: Option<String>,
+
     /// Expose a simple HTTP API on this port
     #[arg(long = "api-port")]
     pub api_port: Option<u16>,

--- a/crates/oxide-miner/src/http_api.rs
+++ b/crates/oxide-miner/src/http_api.rs
@@ -12,8 +12,8 @@ use std::convert::Infallible;
 use std::net::SocketAddr;
 use std::path::PathBuf;
 use std::sync::{atomic::Ordering, Arc};
-use tokio::{fs, net::TcpListener};
 use sysinfo::System;
+use tokio::{fs, net::TcpListener};
 
 // Embed the dashboard assets at compile time so the binary is self-contained.
 const DASHBOARD_HTML: &str = include_str!("../assets/dashboard.html");


### PR DESCRIPTION
## Summary
- add CLI options for supplying custom CA bundles and SHA-256 certificate fingerprints when using TLS
- propagate the new TLS options through miner configuration and reconnection paths
- enhance the stratum TLS client to load custom roots, support fingerprint pinning, and surface clear errors for CA-as-end-entity certificates

## Testing
- cargo test

------
https://chatgpt.com/codex/tasks/task_e_68ddb0dd9d48833382a11e0b9321952f