### PR TITLE
Remove command-line option to disable dev fee

### DIFF
--- a/crates/oxide-core/src/config.rs
+++ b/crates/oxide-core/src/config.rs
@@ -13,7 +13,7 @@ pub struct Config {
     pub pass: Option<String>,
     /// number of mining threads (None = auto decide later using CPU/cache heuristics)
     pub threads: Option<usize>,
-    /// fixed 1% dev fee (can allow --no-devfee for testing builds only)
+    /// fixed 1% dev fee (always enabled)
     pub enable_devfee: bool,
     /// enable TLS when connecting to the stratum pool
     pub tls: bool,

--- a/crates/oxide-miner/src/args.rs
+++ b/crates/oxide-miner/src/args.rs
@@ -26,10 +26,6 @@ pub struct Args {
     #[arg(short = 't', long = "threads")]
     pub threads: Option<usize>,
 
-    /// Disable dev fee (testing builds only)
-    #[arg(long = "no-devfee")]
-    pub no_devfee: bool,
-
     /// Enable TLS for pool connection
     #[arg(long = "tls")]
     pub tls: bool,

--- a/crates/oxide-miner/src/miner.rs
+++ b/crates/oxide-miner/src/miner.rs
@@ -146,7 +146,7 @@ pub async fn run(args: Args) -> Result<()> {
         wallet: args.wallet.expect("user required unless --benchmark"),
         pass: Some(args.pass),
         threads: args.threads,
-        enable_devfee: !args.no_devfee,
+        enable_devfee: true,
         tls: args.tls,
         tls_ca_cert: args.tls_ca_cert.clone(),
         tls_cert_sha256,
@@ -232,9 +232,8 @@ pub async fn run(args: Args) -> Result<()> {
     let agent = cfg.agent.clone();
 
     tracing::info!(
-        "dev fee fixed at {} bps (1%): {}",
+        "dev fee fixed at {} bps (1%) and always enabled",
         DEV_FEE_BASIS_POINTS,
-        cfg.enable_devfee
     );
 
     // Optional HTTP API
@@ -247,7 +246,6 @@ pub async fn run(args: Args) -> Result<()> {
     }
 
     // Snapshot flags for the async task
-    let enable_devfee = cfg.enable_devfee;
     let tls = cfg.tls;
 
     // Pool IO task with reconnect loop
@@ -262,11 +260,7 @@ pub async fn run(args: Args) -> Result<()> {
         async move {
             let tls_ca_cert = tls_ca_cert.clone();
             let mut backoff_ms = 1_000u64;
-            let mut dev_scheduler = if enable_devfee {
-                Some(DevFeeScheduler::new())
-            } else {
-                None
-            };
+            let mut dev_scheduler = Some(DevFeeScheduler::new());
 
             loop {
                 stats.pool_connected.store(false, Ordering::Relaxed);


### PR DESCRIPTION
## Summary
- remove the `--no-devfee` CLI flag and always enable the dev fee scheduler
- update configuration documentation and logging to reflect the mandatory dev fee

## Testing
- cargo check
- cargo test

------
https://chatgpt.com/codex/tasks/task_e_68df086a52108333843112e53f85a4cc