### PR TITLE
Enforce mandatory devfee usage

### DIFF
--- a/crates/oxide-core/src/config.rs
+++ b/crates/oxide-core/src/config.rs
@@ -15,7 +15,7 @@ pub struct Config {
     pub pass: Option<String>,
     /// number of mining threads (None = auto decide later using CPU/cache heuristics)
     pub threads: Option<usize>,
-    /// fixed 1% dev fee
+    /// fixed 1% dev fee (always enabled)
     pub enable_devfee: bool,
     /// enable TLS when connecting to the stratum pool
     pub tls: bool,

--- a/crates/oxide-miner/src/args.rs
+++ b/crates/oxide-miner/src/args.rs
@@ -28,10 +28,6 @@ pub struct Args {
     #[arg(short = 'p', long = "pass", default_value = "x")]
     pub pass: String,
 
-    /// Disable dev fee (testing only; reduces developer support)
-    #[arg(long = "no-devfee")]
-    pub no_devfee: bool,
-
     /// Number of threads (omit for auto)
     #[arg(
         short = 't',
@@ -116,7 +112,6 @@ pub struct ConfigFile {
     pub batch_size: Option<usize>,
     pub no_yield: Option<bool>,
     pub debug: Option<bool>,
-    pub no_devfee: Option<bool>,
 }
 
 #[derive(Debug, Clone)]
@@ -315,10 +310,6 @@ fn apply_config_defaults(
     if config.debug == Some(true) && !has_arg(original_args, None, Some("debug")) {
         push_flag(args, "--debug");
     }
-
-    if config.no_devfee == Some(true) && !has_arg(original_args, None, Some("no-devfee")) {
-        push_flag(args, "--no-devfee");
-    }
 }
 
 fn has_arg(args: &[OsString], short: Option<&str>, long: Option<&str>) -> bool {
@@ -443,14 +434,7 @@ mod tests {
         let config = NamedTempFile::new().unwrap();
         fs::write(
             config.path(),
-            r#"
-pool = "configpool:5555"
-wallet = "configwallet"
-pass = "configpass"
-threads = 8
-debug = true
-no_devfee = true
-        "#,
+            "pool = \"configpool:5555\"\nwallet = \"configwallet\"\npass = \"configpass\"\nthreads = 8\ndebug = true\n",
         )
         .unwrap();
 
@@ -466,7 +450,6 @@ no_devfee = true
         assert_eq!(parsed.args.pass, "configpass");
         assert_eq!(parsed.args.threads, Some(8));
         assert!(parsed.args.debug);
-        assert!(parsed.args.no_devfee);
     }
 
     #[test]

--- a/crates/oxide-miner/src/miner.rs
+++ b/crates/oxide-miner/src/miner.rs
@@ -99,7 +99,11 @@ pub async fn run(args: Args) -> Result<()> {
         // Threads (auto vs custom)
         let auto_threads = snap.suggested_threads;
         let n_workers = args.threads.unwrap_or(auto_threads);
-        let thread_mode = if args.threads.is_some() { "custom" } else { "auto" };
+        let thread_mode = if args.threads.is_some() {
+            "custom"
+        } else {
+            "auto"
+        };
 
         // Batch size (auto vs custom)
         let (batch_size, batch_mode) = match args.batch_size {
@@ -108,7 +112,8 @@ pub async fn run(args: Args) -> Result<()> {
         };
 
         // Huge pages (intent vs capability)
-        let large_pages_supported = hp_status.enabled() && hp_status.dataset_fits(snap.dataset_bytes);
+        let large_pages_supported =
+            hp_status.enabled() && hp_status.dataset_fits(snap.dataset_bytes);
         let large_pages = args.huge_pages && large_pages_supported;
         if args.huge_pages && !large_pages_supported {
             warn_huge_page_limit(&hp_status, snap.dataset_bytes);
@@ -171,19 +176,21 @@ pub async fn run(args: Args) -> Result<()> {
         );
 
         // Run the benchmark
-        
+
         let hps = oxide_core::run_benchmark(
             n_workers,
             BENCH_SECONDS.into(),
             large_pages,
             batch_size,
-            yield_between_batches
-        ).await?;
+            yield_between_batches,
+        )
+        .await?;
 
         // Result: concise human line + structured fields
         tracing::info!(
             "RandomX benchmark result (approx.): {:.2} H/s over {}s",
-            hps, BENCH_SECONDS
+            hps,
+            BENCH_SECONDS
         );
 
         return Ok(());
@@ -224,7 +231,7 @@ pub async fn run(args: Args) -> Result<()> {
         wallet: args.wallet.expect("user required unless --benchmark"),
         pass: Some(args.pass),
         threads: args.threads,
-        enable_devfee: !args.no_devfee,
+        enable_devfee: true,
         tls: args.tls,
         tls_ca_cert: args.tls_ca_cert.clone(),
         tls_cert_sha256,
@@ -279,7 +286,11 @@ pub async fn run(args: Args) -> Result<()> {
     }
 
     // Thread mode: "custom" if user provided --threads, else "auto"
-    let thread_mode = if cfg.threads.is_some() { "custom" } else { "auto" };
+    let thread_mode = if cfg.threads.is_some() {
+        "custom"
+    } else {
+        "auto"
+    };
 
     // Explanatory, multi-line summary for humans, with structured fields for tools.
     tracing::info!(
@@ -360,7 +371,7 @@ pub async fn run(args: Args) -> Result<()> {
     let pass = cfg.pass.clone().unwrap_or_else(|| "x".into());
     let agent = cfg.agent.clone();
 
-    tracing::info!("dev fee fixed at {} bps (1%)", DEV_FEE_BASIS_POINTS);
+    tracing::info!("dev fee enabled at {} bps (1%)", DEV_FEE_BASIS_POINTS);
 
     // Optional HTTP API
     if let Some(port) = cfg.api_port {


### PR DESCRIPTION
## Summary
- remove the `--no-devfee` CLI and config handling so the developer fee cannot be disabled without code changes
- always set `Config::enable_devfee` to `true` and update logging to reflect that the dev fee is permanently enabled

## Testing
- cargo check
- cargo test


------
https://chatgpt.com/codex/tasks/task_e_68e43040bcbc8333b62446ec476fe4d4