### PR TITLE
Embed Windows icon for oxide-miner

### DIFF
--- a/crates/oxide-miner/Cargo.toml
+++ b/crates/oxide-miner/Cargo.toml
@@ -32,3 +32,4 @@ tempfile = "3"
 
 [build-dependencies]
 chrono = { version = "0.4", default-features = false, features = ["clock"] }
+embed-resource = "2.4"


### PR DESCRIPTION
## Summary
- add the embed-resource build dependency for the oxide-miner crate
- extend the build script to package the Windows ICO asset into the executable when targeting Windows

## Testing
- cargo check
- cargo test
- cargo clippy --all-targets -- -D warnings

------
https://chatgpt.com/codex/tasks/task_e_68eaa055ec5c83339ac3f2ac29b04a7c