### PR TITLE
Add release workflow and verification documentation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,150 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+
+permissions:
+  contents: write
+
+env:
+  CARGO_TERM_COLOR: always
+  GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
+  GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
+
+jobs:
+  build:
+    name: Build ${{ matrix.target }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            target: x86_64-unknown-linux-gnu
+            binary: oxide-miner
+            archive: oxide-miner-${{ github.ref_name }}-x86_64-unknown-linux-gnu.tar.gz
+            artifact: oxide-miner-x86_64-unknown-linux-gnu
+          - os: windows-latest
+            target: x86_64-pc-windows-msvc
+            binary: oxide-miner.exe
+            archive: oxide-miner-${{ github.ref_name }}-x86_64-pc-windows-msvc.zip
+            artifact: oxide-miner-x86_64-pc-windows-msvc
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@6d653acede28d24f02e3cd41383119e8b1b35921
+        with:
+          toolchain: stable
+          targets: ${{ matrix.target }}
+
+      - name: Build release binary
+        run: cargo build --release --package oxide-miner --target ${{ matrix.target }}
+
+      - name: Package binary (Linux)
+        if: runner.os == 'Linux'
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p dist
+          BIN_PATH="target/${{ matrix.target }}/release/${{ matrix.binary }}"
+          cp "$BIN_PATH" dist/
+          tar -C dist -czf "dist/${{ matrix.archive }}" "${{ matrix.binary }}"
+          rm "dist/${{ matrix.binary }}"
+
+      - name: Generate checksum (Linux)
+        if: runner.os == 'Linux'
+        shell: bash
+        run: |
+          set -euo pipefail
+          pushd dist >/dev/null
+          ../scripts/generate_sha256.sh "${{ matrix.archive }}.sha256" "${{ matrix.archive }}"
+          popd >/dev/null
+
+      - name: Package binary (Windows)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          New-Item -ItemType Directory -Force -Path dist | Out-Null
+          $Dist = "dist"
+          $BinaryName = "${{ matrix.binary }}"
+          $ArchiveName = "${{ matrix.archive }}"
+          $BinaryPath = Join-Path -Path "target/${{ matrix.target }}/release" -ChildPath $BinaryName
+          $TempBinary = Join-Path -Path $Dist -ChildPath $BinaryName
+          Copy-Item -LiteralPath $BinaryPath -Destination $TempBinary -Force
+          $ArchivePath = Join-Path -Path $Dist -ChildPath $ArchiveName
+          Compress-Archive -LiteralPath $TempBinary -DestinationPath $ArchivePath -Force
+          Remove-Item -LiteralPath $TempBinary
+
+      - name: Generate checksum (Windows)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          $ArchivePath = Join-Path -Path "dist" -ChildPath "${{ matrix.archive }}"
+          $Hash = (Get-FileHash -LiteralPath $ArchivePath -Algorithm SHA256).Hash
+          $Line = "$Hash  ${{ matrix.archive }}"
+          Set-Content -LiteralPath ("dist/${{ matrix.archive }}.sha256") -Value $Line -Encoding ascii
+
+      - name: Upload build artifacts
+        uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3
+        with:
+          name: ${{ matrix.artifact }}
+          path: |
+            dist/${{ matrix.archive }}
+            dist/${{ matrix.archive }}.sha256
+          if-no-files-found: error
+
+  publish:
+    name: Publish release assets
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Download build artifacts
+        uses: actions/download-artifact@c850b930e6ba138125429b7e5c93fc707a7f8427
+        with:
+          path: dist
+
+      - name: Flatten artifact directory
+        shell: bash
+        run: |
+          set -euo pipefail
+          shopt -s nullglob
+          for file in dist/*/*; do
+            if [[ -f "$file" ]]; then
+              mv "$file" dist/
+            fi
+          done
+          find dist -mindepth 1 -type d -empty -delete
+
+      - name: Import GPG private key
+        if: env.GPG_PRIVATE_KEY != ''
+        shell: bash
+        run: |
+          set -euo pipefail
+          echo "$GPG_PRIVATE_KEY" | gpg --batch --import
+
+      - name: Sign release files
+        if: env.GPG_PRIVATE_KEY != ''
+        shell: bash
+        run: |
+          set -euo pipefail
+          shopt -s globstar
+          for file in dist/**/*; do
+            if [[ -f "$file" ]]; then
+              gpg --batch --yes --armor --pinentry-mode loopback ${GPG_PASSPHRASE:+--passphrase "$GPG_PASSPHRASE"} --output "$file.asc" --detach-sign "$file"
+            fi
+          done
+
+      - name: Publish GitHub release assets
+        uses: softprops/action-gh-release@26994186c0ac3ef5cae75ac16aa32e8153525f77
+        with:
+          files: dist/**/*
+          fail_on_unmatched_files: true
+          draft: false
+          generate_release_notes: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Version **v0.1.0** ships a **command-line miner** with automatic CPU tuning, an 
   - [Prerequisites](#prerequisites)
   - [Build and install](#build-and-install)
   - [First run](#first-run)
+- [Downloading and Verifying Releases](#downloading-and-verifying-releases)
 - [Configuration](#configuration)
   - [Command-line flags](#command-line-flags)
   - [Sample `config.toml`](#sample-configtoml)
@@ -127,6 +128,79 @@ Expected startup log flow:
 2. RandomX dataset initialization and worker spawn.
 3. Stratum handshake with the configured pool, including dev-fee scheduler announcements.
 4. HTTP API availability (if `--api-port` is set.)
+
+## Downloading and Verifying Releases
+
+Official release archives are published on the [GitHub Releases](https://github.com/raystanza/OxideMiner/releases) page after the
+CI pipeline finishes building and signing them. Each release upload contains:
+
+- Platform-specific archives such as `oxide-miner-vX.Y.Z-x86_64-unknown-linux-gnu.tar.gz` and
+  `oxide-miner-vX.Y.Z-x86_64-pc-windows-msvc.zip`.
+- Per-archive SHA-256 checksum files (matching the archive name with a `.sha256` suffix).
+- Optional ASCII-armored signature files (`.asc`) that cover both the archive and its checksum when a signing key is configured.
+
+Always verify the integrity of downloads before running them:
+
+### 1. Download the artifacts
+
+1. Visit the [Releases](https://github.com/raystanza/OxideMiner/releases) page.
+2. Pick the tag you want (for example `v0.1.0`) and download the archive and matching `.sha256` file for your platform.
+3. (Optional) Download the `.asc` signature that corresponds to each file if GPG verification is available for that release.
+
+### 2. Verify SHA-256 checksums
+
+Integrity verification ensures the archive was not tampered with in transit. Replace the filenames below with the ones you
+downloaded.
+
+#### Debian and other Linux distributions
+
+```bash
+sha256sum -c oxide-miner-vX.Y.Z-x86_64-unknown-linux-gnu.tar.gz.sha256
+```
+
+The command prints `OK` when the computed digest matches the expected value in the checksum file. If it fails, stop and download
+again from a trusted network.
+
+#### Windows 10/11 (Command Prompt)
+
+```bat
+certutil -hashfile oxide-miner-vX.Y.Z-x86_64-pc-windows-msvc.zip SHA256
+```
+
+Compare the printed hash against the value inside `oxide-miner-vX.Y.Z-x86_64-pc-windows-msvc.zip.sha256`. They must match exactly.
+
+#### Windows 10/11 (PowerShell)
+
+```powershell
+Get-FileHash -Path .\oxide-miner-vX.Y.Z-x86_64-pc-windows-msvc.zip -Algorithm SHA256
+```
+
+Compare the `Hash` field with the checksum file, ignoring letter casing.
+
+### 3. Verify GPG signatures (if provided)
+
+Signature verification protects against malicious mirrors and tampered GitHub uploads. The maintainers publish their release
+signing public key on the release page and in the repository (check the release notes for the canonical download location).
+Import the key and validate the signatures before trusting the binaries.
+
+```bash
+# Import the release signing key (replace the path or URL with the trusted source you use)
+gpg --import path/to/oxide-miner-release.asc
+
+# Inspect the fingerprint and compare it against the one announced in the release notes
+gpg --fingerprint "OxideMiner Release Signing"
+
+# Verify the archive
+gpg --verify oxide-miner-vX.Y.Z-x86_64-unknown-linux-gnu.tar.gz.asc \
+     oxide-miner-vX.Y.Z-x86_64-unknown-linux-gnu.tar.gz
+
+# Verify the checksum file if a signature is provided for it
+gpg --verify oxide-miner-vX.Y.Z-x86_64-unknown-linux-gnu.tar.gz.sha256.asc \
+     oxide-miner-vX.Y.Z-x86_64-unknown-linux-gnu.tar.gz.sha256
+```
+
+Only proceed if GPG reports a valid signature from a trusted key. If verification fails, assume the download has been tampered
+with and contact the maintainers using a secure channel.
 
 ## Configuration
 

--- a/scripts/generate_sha256.sh
+++ b/scripts/generate_sha256.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ $# -lt 2 ]]; then
+  echo "Usage: $0 <output-file> <input-file> [<input-file>...]" >&2
+  exit 1
+fi
+
+output_file="$1"
+shift
+
+: > "$output_file"
+
+if command -v sha256sum >/dev/null 2>&1; then
+  hash_cmd=(sha256sum)
+elif command -v shasum >/dev/null 2>&1; then
+  hash_cmd=(shasum -a 256)
+else
+  echo "Error: no SHA-256 tool available" >&2
+  exit 1
+fi
+
+for input_file in "$@"; do
+  if [[ ! -f "$input_file" ]]; then
+    echo "Error: file '$input_file' does not exist" >&2
+    exit 1
+  fi
+  hash_value=$("${hash_cmd[@]}" "$input_file" | awk '{print $1}')
+  printf '%s  %s\n' "$hash_value" "$(basename "$input_file")" >> "$output_file"
+done
+
+chmod 0644 "$output_file"


### PR DESCRIPTION
## Summary
- add a release workflow that builds oxide-miner for Linux and Windows, generates checksums, and uploads assets to tagged releases
- create a reusable checksum script that enforces SHA-256 hashing with strict error handling
- document how to download, verify, and optionally validate signatures for official release binaries

## Testing
- Not run (workflow and documentation changes only)

------
https://chatgpt.com/codex/tasks/task_e_68eade2370848333916595ac6fab5159