### PR TITLE
Adopt Business Source License 1.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ resolver = "2"
 
 [workspace.package]
 edition = "2021"
-license = "MIT"
+license-file = "LICENSE"
 authors = ["raystanza"]
 
 [workspace.dependencies]

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,61 @@
+License text copyright (c) 2024 Jim Sines. All Rights Reserved.
+"Business Source License" is a trademark of MariaDB Corporation Ab.
+
+Parameters
+
+Licensor:             Jim Sines (@raystanza)
+Licensed Work:        OxideMiner version 0.3.2 and later. The Licensed Work is
+                      (c) 2024 Jim Sines.
+Additional Use Grant: You may make production use of the Licensed Work to mine
+                      digital assets for your own organization or household,
+                      provided you do not offer OxideMiner or derivative works
+                      as a hosted service or commercial product to third
+                      parties.
+Change Date:          2028-01-01
+Change License:       MIT License
+
+Notice
+
+Business Source License 1.1
+
+Terms
+
+The Licensor hereby grants you the right to copy, modify, create derivative
+works, redistribute, and make non-production use of the Licensed Work. The
+Licensor may make an Additional Use Grant, above, permitting limited production
+use.
+
+Effective on the Change Date, or the fourth anniversary of the first publicly
+available distribution of a specific version of the Licensed Work under this
+License, whichever comes first, the Licensor hereby grants you rights under
+the terms of the Change License, and the rights granted in the paragraph
+above terminate.
+
+If your use of the Licensed Work does not comply with the requirements
+currently in effect as described in this License, you must purchase a
+commercial license from the Licensor, its affiliated entities, or authorized
+resellers, or you must refrain from using the Licensed Work.
+
+All copies of the original and modified Licensed Work, and derivative works
+of the Licensed Work, are subject to this License. This License applies
+separately for each version of the Licensed Work and the Change Date may vary
+for each version of the Licensed Work released by Licensor.
+
+You must conspicuously display this License on each original or modified copy
+of the Licensed Work. If you receive the Licensed Work in original or
+modified form from a third party, the terms and conditions set forth in this
+License apply to your use of that work.
+
+Any use of the Licensed Work in violation of this License will automatically
+terminate your rights under this License for the current and all other
+versions of the Licensed Work.
+
+This License does not grant you any right in any trademark or logo of
+Licensor or its affiliates (provided that you may use a trademark or logo of
+Licensor as expressly required by this License).
+
+TO THE EXTENT PERMITTED BY APPLICABLE LAW, THE LICENSED WORK IS PROVIDED ON
+AN "AS IS" BASIS. LICENSOR HEREBY DISCLAIMS ALL WARRANTIES AND CONDITIONS,
+EXPRESS OR IMPLIED, INCLUDING (WITHOUT LIMITATION) WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, NON-INFRINGEMENT, AND
+TITLE.

--- a/README.md
+++ b/README.md
@@ -374,7 +374,7 @@ We welcome issues and pull requests focused on performance, stability, and obser
 
 ## License
 
-The workspace metadata declares OxideMiner under the MIT License (see the `license = "MIT"` entry in [Cargo.toml](Cargo.toml)). Please include the MIT terms when redistributing builds and open an issue if the standalone license text is missing for your use case.
+OxideMiner is distributed under the Business Source License 1.1. The `LICENSE` file spells out the parameters for the grant, including the Additional Use Grant, the Change Date (2028-01-01), and the Change License (MIT). Review those terms before redistributing builds or incorporating the code into other projects, and open an issue if you need a commercial license beyond the Additional Use Grant.
 
 ## Acknowledgments
 


### PR DESCRIPTION
## Summary
- add a Business Source License 1.1 grant tailored for OxideMiner and Jim Sines
- update workspace metadata and documentation to reference the new license file

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f2f5a4654083339649d50ed022d855