### PR TITLE
Fix Tari merge-mining difficulty handling

### DIFF
--- a/crates/oxide-miner/src/miner.rs
+++ b/crates/oxide-miner/src/miner.rs
@@ -1011,6 +1011,12 @@ async fn maybe_fetch_tari_template(
                 .store(template.target_difficulty, Ordering::Relaxed);
             Some(template)
         }
+        Err(oxide_core::tari::TariClientError::MissingAuxData) => {
+            tracing::debug!(
+                "Tari merge mining template fetch failed: proxy response missing Tari aux data"
+            );
+            None
+        }
         Err(e) => {
             tracing::warn!("Tari merge mining template fetch failed: {e}");
             None


### PR DESCRIPTION
## Summary
- require Tari aux chain data when using the Monero-compatible template path and derive difficulty directly from the Tari chain entry
- add coverage for Tari difficulty conversion and aux parsing edge cases
- avoid warning spam by downgrading sub-target Tari shares to debug-only handling

## Testing
- cargo test -p oxide-core --quiet -- --test-threads=1
