### PR TITLE
fix: clarify 'dashboard_dir' usage on Windows in 'config.toml'

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,6 +245,7 @@ threads = 8          # omit to auto-tune
 api_port = 8080      # enable HTTP dashboard
 huge_pages = true    # request HugeTLB / large pages if OS allows it
 # dashboard_dir = "./crates/oxide-miner/assets"   # serve custom UI while developing
+# (on Windows, escape backslashes [e.g. "C:\\path\\to\\dashboard"] or use single quotes [e.g. 'C:\path\to\dashboard'])
 # tls = true
 # tls_ca_cert = "/etc/ssl/certs/ca-certificates.crt"
 # tls_cert_sha256 = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"

--- a/config.toml.example
+++ b/config.toml.example
@@ -44,6 +44,7 @@
 
 # Serve dashboard files from this directory instead of the embedded assets.
 # Useful for local development of the UI.
+# (on Windows, escape backslashes [e.g. "C:\\path\\to\\dashboard"] or use single quotes [e.g. 'C:\path\to\dashboard'])
 #dashboard_dir = "./crates/oxide-miner/assets"
 
 # --- Performance & Scheduling ---


### PR DESCRIPTION
## Summary

- Clarified how to use the 'dashboard_dir' argument in 'config.toml'
- See: 'config.toml.example' and 'README.md'

## Testing

- [x] `cargo fmt`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test --all`

## Checklist

- [x] I have read the [Code of Conduct](../CODE_OF_CONDUCT.md).
- [x] I have read the [Contributing guide](../CONTRIBUTING.md) and confirm this change complies with the BSL-1.1 terms.
- [x] I have added tests or explained why they are not needed.
- [x] I have updated documentation or configuration examples if needed.
- [x] I have linked related issues or discussions.
