### PR TITLE
Feat-add-changelog-to-release-docs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,6 @@ concurrency:
 env:
   CARGO_TERM_COLOR: always
   RELEASE_TAG: ${{ github.ref_name }}
-  LINUX_ARCHIVE_LABEL: x86_64-ubuntu-linux-gnu
 
 jobs:
   build:
@@ -26,14 +25,24 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os: ubuntu-latest
+          - os: ubuntu-24.04
             target: x86_64-unknown-linux-gnu
             archive-extension: tar.gz
             binary-extension: ''
+            linux_archive_label: x86_64-ubuntu24-linux-gnu
+          - os: ubuntu-22.04
+            target: x86_64-unknown-linux-gnu
+            archive-extension: tar.gz
+            binary-extension: ''
+            linux_archive_label: x86_64-ubuntu22-linux-gnu
           - os: windows-latest
             target: x86_64-pc-windows-msvc
             archive-extension: zip
             binary-extension: .exe
+          - os: macos-13
+            target: x86_64-apple-darwin
+            archive-extension: tar.gz
+            binary-extension: ''
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -69,8 +78,8 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          if [[ "${{ matrix.os }}" == "ubuntu-latest" ]]; then
-            release_suffix="$LINUX_ARCHIVE_LABEL"
+          if [[ "${{ matrix.os }}" == ubuntu-* ]]; then
+            release_suffix="${{ matrix.linux_archive_label }}"
           else
             release_suffix="${{ matrix.target }}"
           fi
@@ -79,7 +88,7 @@ jobs:
           echo "CHECKSUM_NAME=oxide-miner-${RELEASE_TAG}-${release_suffix}.sha256" >> "$GITHUB_ENV"
 
       - name: List built files (Linux)
-        if: ${{ matrix.os == 'ubuntu-latest' }}
+        if: ${{ startsWith(matrix.os, 'ubuntu-') }}
         shell: bash
         run: |
           set -euo pipefail
@@ -88,7 +97,7 @@ jobs:
           ls -la "$CARGO_TARGET_DIR/release" || true
 
       - name: Prepare Linux artifact (binary + config + scripts)
-        if: ${{ matrix.os == 'ubuntu-latest' }}
+        if: ${{ startsWith(matrix.os, 'ubuntu-') || matrix.os == 'macos-13' }}
         shell: bash
         run: |
           set -euo pipefail
@@ -162,7 +171,11 @@ jobs:
           rm -rf "$pkg_dir"
 
           # Checksums (archive only)
-          bash scripts/release/generate-checksums.sh "$dist_dir/$CHECKSUM_NAME" "$dist_dir/$ARCHIVE_NAME"
+          if [[ "${{ matrix.os }}" == "macos-13" ]]; then
+            shasum -a 256 "$dist_dir/$ARCHIVE_NAME" > "$dist_dir/$CHECKSUM_NAME"
+          else
+            bash scripts/release/generate-checksums.sh "$dist_dir/$CHECKSUM_NAME" "$dist_dir/$ARCHIVE_NAME"
+          fi
 
       # Setup GPG on Windows, with choco fallback
       - name: Ensure GnuPG (Windows)
@@ -271,7 +284,7 @@ jobs:
           "$($hash.Hash.ToLower())  $($env:ARCHIVE_NAME)" | Out-File -FilePath $checksumFile -Encoding ascii
 
       - name: Sign artifacts (Linux)
-        if: ${{ matrix.os == 'ubuntu-latest' }}
+        if: ${{ startsWith(matrix.os, 'ubuntu-') }}
         env:
           GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
           GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
@@ -320,7 +333,7 @@ jobs:
       - name: Upload build artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: oxide-miner-${{ matrix.target }}
+          name: oxide-miner-${{ matrix.os }}-${{ matrix.target }}
           path: dist/*
           if-no-files-found: error
 


### PR DESCRIPTION
## Summary

- Expanded the build matrix to the requested OS set and made Ubuntu artifacts uniquely labeled so release assets don’t clobber each other, while keeping release/changelog logic intact.

- Added a macOS-specific checksum fallback in the existing Linux/macOS packaging step so macos-13 doesn’t rely on sha256sum.

## Testing

- none: automated workflow changes only.

## Checklist

- [x] I have read the [Code of Conduct](../CODE_OF_CONDUCT.md).
- [x] I have read the [Contributing guide](../CONTRIBUTING.md) and confirm this change complies with the BSL-1.1 terms.
- [x] I have added tests or explained why they are not needed.
- [x] I have updated documentation or configuration examples if needed.
